### PR TITLE
Bitmap Refactor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ resources/textures/logo.png filter=lfs diff=lfs merge=lfs -text
 resources/icons/logo.ico filter=lfs diff=lfs merge=lfs -text
 resources/textures/provinces.png filter=lfs diff=lfs merge=lfs -text
 tests/bin/8bpp_greyscale_no_color_management.bmp filter=lfs diff=lfs merge=lfs -text
+tests/bin/8bpp_greyscale.bmp filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ resources/textures/selection.bmp filter=lfs diff=lfs merge=lfs -text
 resources/textures/logo.png filter=lfs diff=lfs merge=lfs -text
 resources/icons/logo.ico filter=lfs diff=lfs merge=lfs -text
 resources/textures/provinces.png filter=lfs diff=lfs merge=lfs -text
+tests/bin/8bpp_greyscale_no_color_management.bmp filter=lfs diff=lfs merge=lfs -text

--- a/mod_dev_tool/common/inc/BitMap.h
+++ b/mod_dev_tool/common/inc/BitMap.h
@@ -20,7 +20,7 @@ namespace HMDT {
     constexpr uint32_t V1_INFO_HEADER_LENGTH = 40;
 
     //! The length of the V4 InfoHeader (108 bytes)
-    constexpr uint32_t V4_INFO_HEADER_LENGTH = V1_INFO_HEADER_LENGTH + 54;
+    constexpr uint32_t V4_INFO_HEADER_LENGTH = V1_INFO_HEADER_LENGTH + 68;
 
     //! The length of the V5 InfoHeader (124 bytes)
     constexpr uint32_t V5_INFO_HEADER_LENGTH = V4_INFO_HEADER_LENGTH + 16;

--- a/mod_dev_tool/common/inc/BitMap.h
+++ b/mod_dev_tool/common/inc/BitMap.h
@@ -10,7 +10,21 @@
 # include <ostream> // std::ostream
 # include <filesystem> // std::filesystem::path
 
+# include "Maybe.h"
+
 namespace HMDT {
+    //! The length of the FileHeader
+    constexpr uint32_t FILE_HEADER_LENGTH = 14;
+
+    //! The length of the V1 InfoHeader
+    constexpr uint32_t V1_INFO_HEADER_LENGTH = 40;
+
+    //! The length of the V4 InfoHeader (108 bytes)
+    constexpr uint32_t V4_INFO_HEADER_LENGTH = V1_INFO_HEADER_LENGTH + 54;
+
+    //! The length of the V5 InfoHeader (124 bytes)
+    constexpr uint32_t V5_INFO_HEADER_LENGTH = V4_INFO_HEADER_LENGTH + 16;
+
     /**
      * @brief Defines the file header section of a .BMP file.
      */
@@ -26,7 +40,7 @@ namespace HMDT {
      * @brief Defines the info section of a .BMP file.
      */
     struct BitMapInfoHeader {
-        unsigned int headerSize;     //! The size of the header (always 40)
+        unsigned int headerSize;     //! The size of the header
         int width;                   //! The width of the file
         int height;                  //! The height of the file
         unsigned short bitPlanes;    //! IGNORED
@@ -40,22 +54,134 @@ namespace HMDT {
     };
 
     /**
+     * @brief Specifies the type of color space.
+     * @details For more information, see the Microsoft documentation at:
+     *          https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/eb4bbd50-b3ce-4917-895c-be31f214797f
+     */
+    enum class LogicalColorSpace: uint32_t {
+        CALIBRATED_RGB = 0,
+        SRGB = 0x73524742,
+        WINDOWS_COLOR_SPACE = 0x57696E20
+    };
+
+    /**
+     * @brief Defines the V4 info section of a .BMP file
+     */
+    struct BitMapInfoHeaderV4 {
+        BitMapInfoHeader v1; //! The V1 header information
+
+        uint32_t redMask;
+        uint32_t greenMask;
+        uint32_t blueMask;
+        uint32_t alphaMask;
+        LogicalColorSpace CSType;
+
+        // endpoints
+        uint32_t redX;
+        uint32_t redY;
+        uint32_t redZ;
+        uint32_t greenX;
+        uint32_t greenY;
+        uint32_t greenZ;
+        uint32_t blueX;
+        uint32_t blueY;
+        uint32_t blueZ;
+
+        uint32_t gammaRed;
+        uint32_t gammaGreen;
+        uint32_t gammaBlue;
+    };
+
+    struct BitMapInfoHeaderV5 {
+        BitMapInfoHeaderV4 v4; //! The V4 header information
+
+        uint32_t profileData;
+        uint32_t profileSize;
+        uint32_t reserved;
+    };
+
+    /**
+     * @brief Defines the RGBQUAD struct used in the .BMP file's color table.
+     */
+    union RGBQuad {
+        struct {
+            uint8_t blue;
+            uint8_t green;
+            uint8_t red;
+            uint8_t reserved; // Alpha?
+        };
+
+        uint32_t rgb_quad;
+    };
+
+    /**
      * @brief A simple representation of a Bit Map image.
      */
-    struct BitMap {
+    struct [[deprecated]] BitMap {
         BitMapFileHeader file_header; //! The file header of the BitMap
         BitMapInfoHeader info_header; //! The info header of the BitMap
+
         unsigned char* data;          //! The image data
     };
 
-    BitMap* readBMP(const std::filesystem::path&, BitMap*);
-    BitMap* readBMP(std::istream&, BitMap*);
-    BitMap* readBMP(const std::filesystem::path&);
+    /**
+     * @brief A representation of a BitMap image
+     * @details The info_header  will be one of v1, v4, or v5 depending on the
+     *          value of BitMapInfoHeader::headerSize. V1 is guaranteed to
+     *          always be valid.
+     */
+    struct BitMap2 {
+        BitMapFileHeader file_header; //! The file header of the BitMap
 
-    void writeBMP(const std::filesystem::path&, const BitMap*);
-    void writeBMP(const std::filesystem::path&, unsigned char*, uint32_t, uint32_t, uint16_t = 3);
+        /**
+         * @brief This union will hold each different possible header.
+         * @details Every header _must_ be listed in the order in which they
+         *          inherit from each other, so that the memory layout is
+         *          exactly the same regardless of if we access the smaller
+         *          headers directly or via the larger headers.
+         */
+        union {
+            BitMapInfoHeader v1;      //! V1 header
+            BitMapInfoHeaderV4 v4;    //! V4 header
+            BitMapInfoHeaderV5 v5;    //! V5 header
+        } info_header;                //! The info header of the BitMap
+
+        std::unique_ptr<RGBQuad[]> color_table; //! The color table of the BitMap. Can be nullptr
+        std::unique_ptr<unsigned char[]> data;  //! The image data
+    };
+
+    [[deprecated]] BitMap* readBMP(const std::filesystem::path&, BitMap*);
+    [[deprecated]] BitMap* readBMP(std::istream&, BitMap*);
+    [[deprecated]] BitMap* readBMP(const std::filesystem::path&);
+
+    [[deprecated]] void writeBMP(const std::filesystem::path&, const BitMap*);
+    [[deprecated]] void writeBMP(const std::filesystem::path&, unsigned char*,
+                                 uint32_t, uint32_t, uint16_t = 3);
 
     std::ostream& operator<<(std::ostream&, const HMDT::BitMap&);
+
+
+    /**
+     * @brief An enum listing all supported BMP info headers
+     */
+    enum class BMPHeaderToUse { V1, V4, V5 };
+
+    MaybeRef<BitMap2> readBMP(const std::filesystem::path&,
+                              std::shared_ptr<BitMap2>);
+    MaybeRef<BitMap2> readBMP(std::istream&, std::shared_ptr<BitMap2>);
+
+    MaybeRef<BitMap2> readBMP(const std::filesystem::path&, BitMap2&);
+    MaybeRef<BitMap2> readBMP(std::istream&, BitMap2&);
+    Maybe<BitMap2> readBMP2(std::filesystem::path&);
+
+    MaybeVoid writeBMP(const std::filesystem::path&,
+                       std::shared_ptr<const BitMap2>);
+    MaybeVoid writeBMP(const std::filesystem::path&, const BitMap2&);
+    MaybeVoid writeBMP2(const std::filesystem::path&, unsigned char*,
+                        uint32_t, uint32_t, uint16_t = 3, bool = false,
+                        BMPHeaderToUse = BMPHeaderToUse::V4);
+
+    std::ostream& operator<<(std::ostream&, const HMDT::BitMap2&);
 }
 
 #endif

--- a/mod_dev_tool/common/inc/Maybe.h
+++ b/mod_dev_tool/common/inc/Maybe.h
@@ -87,8 +87,9 @@ namespace HMDT {
             { }
 
             template<typename U = T,
-                     typename = std::enable_if_t<!std::is_same_v<U, Maybe<T>> ||
-                                                 !std::is_same_v<U, MonadOptional<T>>>
+                     typename = std::enable_if_t<!std::is_same_v<U, Maybe<T>> &&
+                                                 !std::is_same_v<U, MonadOptional<T>> &&
+                                                 std::is_convertible_v<U, T>>
                     >
             constexpr Maybe(U&& value): MonadOptional<T>(std::forward<U>(value))
             { }

--- a/mod_dev_tool/common/inc/Maybe.h
+++ b/mod_dev_tool/common/inc/Maybe.h
@@ -86,6 +86,13 @@ namespace HMDT {
                 MonadOptional<T>(value), m_ec()
             { }
 
+            template<typename U = T,
+                     typename = std::enable_if_t<!std::is_same_v<U, Maybe<T>> ||
+                                                 !std::is_same_v<U, MonadOptional<T>>>
+                    >
+            constexpr Maybe(U&& value): MonadOptional<T>(std::forward<U>(value))
+            { }
+
             template<typename U = T>
             Maybe(const Maybe<U>& maybe):
                 Maybe<T>(maybe, Identity_t<U>{})
@@ -101,7 +108,7 @@ namespace HMDT {
             { }
 
             Maybe(Maybe<T>&& maybe):
-                MonadOptional<T>(std::forward<Maybe<T>>(maybe)),
+                MonadOptional<T>(std::forward<MonadOptional<T>>(maybe)),
                 m_ec(std::move(maybe.m_ec))
             { }
 

--- a/mod_dev_tool/common/inc/Monad.h
+++ b/mod_dev_tool/common/inc/Monad.h
@@ -50,8 +50,10 @@ namespace HMDT {
                 m_opt(i, ilist, args...)
             { }
 
-            template<typename U = T>
-            constexpr MonadOptional(U&& value): m_opt(value)
+            template<typename U = T,
+                     typename = std::enable_if_t<!std::is_same_v<U, MonadOptional<T>>>
+                    >
+            constexpr MonadOptional(U&& value): m_opt(std::forward<U>(value))
             { }
 
             MonadOptional(const MonadOptional<T>& mopt): m_opt(mopt.m_opt)

--- a/mod_dev_tool/common/inc/StatusCodesDef.h
+++ b/mod_dev_tool/common/inc/StatusCodesDef.h
@@ -19,6 +19,7 @@
     X(SUCCESS, "Success") \
     X(BADALLOC, "Memory allocation failed.") \
     X(NOT_IMPLEMENTED, "Feature is not implemented yet.") \
+    X(PARAM_CANNOT_BE_NULL, "Given parameter may not be null.") \
     /* Project Error Codes */ \
     Y(PROJECT, 0x100) \
     X(PROJECT_VALIDATION_FAILED, "Project Validation Failed.") \
@@ -40,9 +41,17 @@
     /* ShapeFinder Error Codes */ \
     Y(SHAPEFINDER, 0x5000) \
     X(SHAPEFINDER_ESTOP, "Shape Finder was stopped early.") \
+    /* File Error Codes */ \
+    Y(FILECODES, 0x10000) \
+    X(CANNOT_READ_FROM_STREAM, "Unable to read from the given stream.") \
+    X(READ_TOO_FEW_BYTES, "Too few bytes were read from the given stream.") \
     /* Logger Error Codes */ \
     Y(LOGGER, 0x16000) \
     X(INVALID_LEVEL_STRING, "String is unable to be converted to a level enum.") \
+    /* BitMap Error Codes */ \
+    Y(BITMAP, 0x16200) \
+    X(BITMAP_OFFSET_VALIDATION_ERROR, "Validation using the BitMap's offset failed.") \
+    X(INVALID_BITS_PER_PIXEL, "Invalid Bits Per Pixel.") \
 
 #endif
 

--- a/mod_dev_tool/common/src/BitMap.cpp
+++ b/mod_dev_tool/common/src/BitMap.cpp
@@ -487,7 +487,7 @@ auto HMDT::readBMP2(std::filesystem::path& path) -> Maybe<BitMap2> {
     auto res = readBMP(path, bm);
     RETURN_IF_ERROR(res);
 
-    return std::move(bm);
+    return bm;
 }
 
 auto HMDT::writeBMP(const std::filesystem::path& path,

--- a/mod_dev_tool/common/src/BitMap.cpp
+++ b/mod_dev_tool/common/src/BitMap.cpp
@@ -473,6 +473,8 @@ auto HMDT::readBMP(std::istream& stream, BitMap2& bm) -> MaybeRef<BitMap2> {
                          bm.info_header.v1.height);
     RETURN_IF_ERROR(res);
 
+    WRITE_DEBUG("Successfully loaded ", bm);
+
     return std::ref(bm);
 
 #undef READ_FROM_BMP
@@ -637,8 +639,7 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
                      bool is_greyscale, BMPHeaderToUse hdr_version_to_use)
     -> MaybeVoid
 {
-    BitMap2 bmp;
-    std::memset(&bmp, 0, sizeof(BitMap2));
+    BitMap2 bmp{};
 
     // Make sure we release the grabbed 'data' pointer when we exit, as it is
     //   not ours to delete
@@ -666,6 +667,8 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
             bmp.info_header.v5.profileData = 0;
             bmp.info_header.v5.profileSize = 0;
             bmp.info_header.v5.reserved = 0;
+
+            [[fallthrough]];
         case BMPHeaderToUse::V4:
             info_header_size += (V4_INFO_HEADER_LENGTH - V1_INFO_HEADER_LENGTH);
 
@@ -689,6 +692,8 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
             bmp.info_header.v4.gammaRed = 0;
             bmp.info_header.v4.gammaGreen = 0;
             bmp.info_header.v4.gammaBlue = 0;
+
+            [[fallthrough]];
         case BMPHeaderToUse::V1:
             info_header_size += V1_INFO_HEADER_LENGTH;
 

--- a/mod_dev_tool/common/src/BitMap.cpp
+++ b/mod_dev_tool/common/src/BitMap.cpp
@@ -654,7 +654,7 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
     bmp.file_header.reserved2 = 0;
     bmp.file_header.bitmapOffset = FILE_HEADER_LENGTH;
 
-    auto info_header_size = FILE_HEADER_LENGTH;
+    auto info_header_size = 0;
 
     // Fill out the info header based on what version is requested
     //   Note: we populate it backwards to take advantage of switch-case
@@ -729,6 +729,9 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
                             bmp.info_header.v1.bitsPerPixel);
                 RETURN_ERROR(STATUS_INVALID_BITS_PER_PIXEL);
         }
+
+        // colorsImportant will always match colorsUsed
+        bmp.info_header.v1.colorImportant = bmp.info_header.v1.colorsUsed;
 
         WRITE_DEBUG("Generating color table with ", bmp.info_header.v1.colorsUsed,
                     " values.");

--- a/mod_dev_tool/common/src/BitMap.cpp
+++ b/mod_dev_tool/common/src/BitMap.cpp
@@ -662,14 +662,12 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
     switch(hdr_version_to_use) {
         case BMPHeaderToUse::V5:
             info_header_size += (V5_INFO_HEADER_LENGTH - V4_INFO_HEADER_LENGTH);
-            WRITE_DEBUG("info_header_size=", info_header_size);
 
             bmp.info_header.v5.profileData = 0;
             bmp.info_header.v5.profileSize = 0;
             bmp.info_header.v5.reserved = 0;
         case BMPHeaderToUse::V4:
             info_header_size += (V4_INFO_HEADER_LENGTH - V1_INFO_HEADER_LENGTH);
-            WRITE_DEBUG("info_header_size=", info_header_size);
 
             bmp.info_header.v4.redMask   = 0x00FF0000;
             bmp.info_header.v4.greenMask = 0x0000FF00;
@@ -693,7 +691,6 @@ auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
             bmp.info_header.v4.gammaBlue = 0;
         case BMPHeaderToUse::V1:
             info_header_size += V1_INFO_HEADER_LENGTH;
-            WRITE_DEBUG("info_header_size=", info_header_size);
 
             bmp.info_header.v1.headerSize = info_header_size;
             bmp.info_header.v1.width = static_cast<int>(width);

--- a/mod_dev_tool/common/src/BitMap.cpp
+++ b/mod_dev_tool/common/src/BitMap.cpp
@@ -213,6 +213,8 @@ void HMDT::writeBMP(const std::filesystem::path& path, const BitMap* bmp) {
         file.write(reinterpret_cast<const char*>(output.get()),
                    bmp->info_header.sizeOfBitmap);
     }
+
+#undef WRITE_BMP_VALUE
 }
 
 /**
@@ -222,6 +224,7 @@ void HMDT::writeBMP(const std::filesystem::path& path, const BitMap* bmp) {
  * @param data The color data to write
  * @param width The width of the bitmap
  * @param height The height of the bitmap
+ * @param depth The bit-depth of the bitmap
  */
 void HMDT::writeBMP(const std::filesystem::path& path, unsigned char* data,
                     uint32_t width, uint32_t height, uint16_t depth)
@@ -287,6 +290,570 @@ std::ostream& HMDT::operator<<(std::ostream& stream, const HMDT::BitMap& bm) {
            << "    vertResolution = " << bm.info_header.vertResolution << std::endl
            << "    colorsUsed = " << bm.info_header.colorsUsed << std::endl
            << "    colorImportant = " << bm.info_header.colorImportant << std::endl
+           << "    data = { ... }" << std::endl
+           << "}";
+
+    return stream;
+}
+
+auto HMDT::readBMP(const std::filesystem::path& path,
+                   std::shared_ptr<BitMap2> bm)
+    -> MaybeRef<BitMap2>
+{
+    if(bm == nullptr) {
+        RETURN_ERROR(STATUS_PARAM_CANNOT_BE_NULL);
+    }
+
+    return readBMP(path, *bm);
+}
+
+auto HMDT::readBMP(const std::filesystem::path& path, BitMap2& bm)
+    -> MaybeRef<BitMap2>
+{
+    // Make sure we clear errno first
+    errno = 0;
+
+    std::ifstream file(path, std::ios::in | std::ios::binary);
+
+    if(!file.is_open()) {
+        WRITE_ERROR("Failed to open bitmap file ", path);
+        RETURN_ERROR(std::error_code(errno, std::generic_category()));
+    }
+
+    auto res = readBMP(file, bm);
+    RETURN_IF_ERROR(res);
+
+    return res;
+}
+
+auto HMDT::readBMP(std::istream& stream,
+                   std::shared_ptr<BitMap2> bm)
+    -> MaybeRef<BitMap2>
+{
+    if(bm == nullptr) {
+       RETURN_ERROR(STATUS_PARAM_CANNOT_BE_NULL);
+    }
+
+    auto res = readBMP(stream, bm);
+    RETURN_IF_ERROR(res);
+
+    return res;
+}
+
+auto HMDT::readBMP(std::istream& stream, BitMap2& bm) -> MaybeRef<BitMap2> {
+#define READ_FROM_BMP(FIELD)                    \
+    do {                                        \
+        auto res = safeRead2(FIELD, stream); \
+        RETURN_IF_ERROR(res);                   \
+    } while(0)
+#define READ_FROM_BMP2(FIELD, SIZE)                   \
+    do {                                              \
+        auto res = safeRead2(FIELD, SIZE, stream); \
+        RETURN_IF_ERROR(res);                         \
+    } while(0)
+
+    // Safely read the entire header into the struct.
+    READ_FROM_BMP(&(bm.file_header.filetype));
+    READ_FROM_BMP(&(bm.file_header.fileSize));
+    READ_FROM_BMP(&(bm.file_header.reserved1));
+    READ_FROM_BMP(&(bm.file_header.reserved2));
+    READ_FROM_BMP(&(bm.file_header.bitmapOffset));
+    READ_FROM_BMP(&(bm.info_header.v1.headerSize));
+    READ_FROM_BMP(&(bm.info_header.v1.width));
+    READ_FROM_BMP(&(bm.info_header.v1.height));
+    READ_FROM_BMP(&(bm.info_header.v1.bitPlanes));
+    READ_FROM_BMP(&(bm.info_header.v1.bitsPerPixel));
+    READ_FROM_BMP(&(bm.info_header.v1.compression));
+    READ_FROM_BMP(&(bm.info_header.v1.sizeOfBitmap));
+    READ_FROM_BMP(&(bm.info_header.v1.horzResolution));
+    READ_FROM_BMP(&(bm.info_header.v1.vertResolution));
+    READ_FROM_BMP(&(bm.info_header.v1.colorsUsed));
+    READ_FROM_BMP(&(bm.info_header.v1.colorImportant));
+
+    // Read the V4 part of the header
+    if(bm.info_header.v1.headerSize >= 108) {
+        READ_FROM_BMP(&(bm.info_header.v4.redMask));
+        READ_FROM_BMP(&(bm.info_header.v4.greenMask));
+        READ_FROM_BMP(&(bm.info_header.v4.blueMask));
+        READ_FROM_BMP(&(bm.info_header.v4.alphaMask));
+        READ_FROM_BMP(&(bm.info_header.v4.CSType));
+
+        READ_FROM_BMP(&(bm.info_header.v4.redX));
+        READ_FROM_BMP(&(bm.info_header.v4.redY));
+        READ_FROM_BMP(&(bm.info_header.v4.redZ));
+        READ_FROM_BMP(&(bm.info_header.v4.greenX));
+        READ_FROM_BMP(&(bm.info_header.v4.greenY));
+        READ_FROM_BMP(&(bm.info_header.v4.greenZ));
+        READ_FROM_BMP(&(bm.info_header.v4.blueX));
+        READ_FROM_BMP(&(bm.info_header.v4.blueY));
+        READ_FROM_BMP(&(bm.info_header.v4.blueZ));
+
+        READ_FROM_BMP(&(bm.info_header.v4.gammaRed));
+        READ_FROM_BMP(&(bm.info_header.v4.gammaGreen));
+        READ_FROM_BMP(&(bm.info_header.v4.gammaBlue));
+    }
+
+    // TODO: Do we need to worry about the V5 header?
+
+
+    // Read the color table, if one exists
+
+    // TODO: Do we also have to worry about compression here?
+    //       See: https://stackoverflow.com/a/25072672
+    if(bm.info_header.v1.colorsUsed > 0) {
+        try {
+            bm.color_table.reset(new RGBQuad[bm.info_header.v1.colorsUsed]);
+        } catch(const std::bad_alloc& e) {
+            WRITE_ERROR("Failed to allocate enough space for the bitmap's color table (",
+                        bm.info_header.v1.colorsUsed * sizeof(RGBQuad),
+                        " bytes required): ",
+                        e.what());
+            RETURN_ERROR(STATUS_BADALLOC);
+        }
+
+        for(auto i = 0U; i < bm.info_header.v1.colorsUsed; ++i) {
+            READ_FROM_BMP(&(bm.color_table[i].blue));
+            READ_FROM_BMP(&(bm.color_table[i].green));
+            READ_FROM_BMP(&(bm.color_table[i].red));
+            READ_FROM_BMP(&(bm.color_table[i].reserved));
+        }
+    }
+
+    size_t depth = bm.info_header.v1.bitsPerPixel / 8;
+
+    // Calculate how many bytes make up one line
+    size_t orig_pitch = bm.info_header.v1.width * bm.info_header.v1.bitsPerPixel;
+    size_t new_pitch = bm.info_header.v1.width * depth; // This is how many we _want_ each line to take up.
+
+    // Allocate space for our new image data
+    try {
+        bm.data.reset(new unsigned char[new_pitch * bm.info_header.v1.height]);
+    } catch(const std::bad_alloc& e) {
+        WRITE_ERROR("Failed to allocate enough space for the bitmap's data (",
+                    new_pitch * bm.info_header.v1.height, " bytes required): ",
+                    e.what());
+
+        RETURN_ERROR(STATUS_BADALLOC);
+    }
+
+    // Make sure we read where the file tells us the offset is, and not just
+    //  assume that the data starts after the header (it doesn't always do that)
+    if(auto pos = stream.tellg(); pos != bm.file_header.bitmapOffset) {
+        WRITE_WARN("Did not read expected number of bytes from the header! We "
+                   "expected to be at the bitmap offset (",
+                   bm.file_header.bitmapOffset, ") but we are instead at ",
+                   stream.tellg(), ". Attempting to seek to the expected offset.");
+
+        stream.seekg(bm.file_header.bitmapOffset, stream.beg);
+        WRITE_DEBUG("Current position after seek: ", stream.tellg());
+    }
+
+    // Read the pixel data from the stream next
+    READ_FROM_BMP2(bm.data.get(), bm.info_header.v1.sizeOfBitmap);
+
+    if(orig_pitch % 4 != 0) {
+        WRITE_WARN("BitMap Width is not a multiple of 4! May contain up to ",
+                   (orig_pitch / 4), " padding bytes.");
+    }
+
+    // Only flip the bytes for 24-bit images
+    if(depth == 3) {
+        WRITE_DEBUG("Swapping BGR to RGB before writing the BitMap.");
+        // Swap B and R every 3 pixels since BitMap expects pixels in BGR rather
+        //   than RGB format
+        for(size_t i = 2; i < bm.info_header.v1.sizeOfBitmap; i += depth) {
+            std::swap(bm.data[i], bm.data[i - 2]);
+        }
+    }
+
+    //----------------
+    // Flip the entire image, because BitMap is a weird format.
+    //----------------
+    auto res = flipImage(bm.data.get(), bm.data.get(), new_pitch,
+                         bm.info_header.v1.height);
+    RETURN_IF_ERROR(res);
+
+    return std::ref(bm);
+
+#undef READ_FROM_BMP
+#undef READ_FROM_BMP2
+}
+
+auto HMDT::readBMP2(std::filesystem::path& path) -> Maybe<BitMap2> {
+    BitMap2 bm;
+
+    auto res = readBMP(path, bm);
+    RETURN_IF_ERROR(res);
+
+    return std::move(bm);
+}
+
+auto HMDT::writeBMP(const std::filesystem::path& path,
+                    std::shared_ptr<const BitMap2> bmp)
+    -> MaybeVoid
+{
+    if(bmp == nullptr) {
+       RETURN_ERROR(STATUS_PARAM_CANNOT_BE_NULL);
+    }
+
+    auto res = writeBMP(path, *bmp);
+    RETURN_IF_ERROR(res);
+
+    return res;
+}
+
+auto HMDT::writeBMP(const std::filesystem::path& path, const BitMap2& bmp)
+    -> MaybeVoid
+{
+    std::ofstream file(path, std::ios::out | std::ios::binary);
+
+    if(!file) {
+        WRITE_ERROR("Failed to open output file ", path);
+        RETURN_ERROR(std::error_code(errno, std::generic_category()));
+    }
+
+    WRITE_DEBUG(bmp);
+
+    // Helper macro to make the following code easier to read
+#define WRITE_BMP_VALUE(MEMBER) \
+    file.write(reinterpret_cast<const char*>(&(MEMBER)), \
+               sizeof(MEMBER))
+
+    WRITE_BMP_VALUE(bmp.file_header.filetype);
+    WRITE_BMP_VALUE(bmp.file_header.fileSize);
+    WRITE_BMP_VALUE(bmp.file_header.reserved1);
+    WRITE_BMP_VALUE(bmp.file_header.reserved2);
+    WRITE_BMP_VALUE(bmp.file_header.bitmapOffset);
+    WRITE_BMP_VALUE(bmp.info_header.v1.headerSize);
+    WRITE_BMP_VALUE(bmp.info_header.v1.width);
+    WRITE_BMP_VALUE(bmp.info_header.v1.height);
+    WRITE_BMP_VALUE(bmp.info_header.v1.bitPlanes);
+    WRITE_BMP_VALUE(bmp.info_header.v1.bitsPerPixel);
+    WRITE_BMP_VALUE(bmp.info_header.v1.compression);
+    WRITE_BMP_VALUE(bmp.info_header.v1.sizeOfBitmap);
+    WRITE_BMP_VALUE(bmp.info_header.v1.horzResolution);
+    WRITE_BMP_VALUE(bmp.info_header.v1.vertResolution);
+    WRITE_BMP_VALUE(bmp.info_header.v1.colorsUsed);
+    WRITE_BMP_VALUE(bmp.info_header.v1.colorImportant);
+
+    // Write the V4 header
+    if(bmp.info_header.v1.headerSize >= V4_INFO_HEADER_LENGTH) {
+        WRITE_BMP_VALUE(bmp.info_header.v4.redMask);
+        WRITE_BMP_VALUE(bmp.info_header.v4.greenMask);
+        WRITE_BMP_VALUE(bmp.info_header.v4.blueMask);
+        WRITE_BMP_VALUE(bmp.info_header.v4.alphaMask);
+        WRITE_BMP_VALUE(bmp.info_header.v4.CSType);
+
+        WRITE_BMP_VALUE(bmp.info_header.v4.redX);
+        WRITE_BMP_VALUE(bmp.info_header.v4.redY);
+        WRITE_BMP_VALUE(bmp.info_header.v4.redZ);
+        WRITE_BMP_VALUE(bmp.info_header.v4.greenX);
+        WRITE_BMP_VALUE(bmp.info_header.v4.greenY);
+        WRITE_BMP_VALUE(bmp.info_header.v4.greenZ);
+        WRITE_BMP_VALUE(bmp.info_header.v4.blueX);
+        WRITE_BMP_VALUE(bmp.info_header.v4.blueY);
+        WRITE_BMP_VALUE(bmp.info_header.v4.blueZ);
+
+        WRITE_BMP_VALUE(bmp.info_header.v4.gammaRed);
+        WRITE_BMP_VALUE(bmp.info_header.v4.gammaGreen);
+        WRITE_BMP_VALUE(bmp.info_header.v4.gammaBlue);
+    }
+
+    // Write the V5 header
+    if(bmp.info_header.v1.headerSize >= V5_INFO_HEADER_LENGTH) {
+        WRITE_BMP_VALUE(bmp.info_header.v5.profileData);
+        WRITE_BMP_VALUE(bmp.info_header.v5.profileSize);
+        WRITE_BMP_VALUE(bmp.info_header.v5.reserved);
+    }
+
+    if(bmp.color_table != nullptr) {
+        WRITE_DEBUG("Writing color table with ", bmp.info_header.v1.colorsUsed,
+                    " values.");
+        for(auto i = 0U; i < bmp.info_header.v1.colorsUsed; ++i) {
+            WRITE_BMP_VALUE(bmp.color_table[i].blue);
+            WRITE_BMP_VALUE(bmp.color_table[i].green);
+            WRITE_BMP_VALUE(bmp.color_table[i].red);
+            WRITE_BMP_VALUE(bmp.color_table[i].reserved);
+        }
+    }
+
+    // Verify that the offset matches where in the file we are
+    if(auto stream_loc = file.tellp();
+            stream_loc != bmp.file_header.bitmapOffset)
+    {
+        WRITE_ERROR("Validation error! Calculated bitmapOffset of ",
+                    bmp.file_header.bitmapOffset, " does not match number of "
+                    "bytes we've written so far of ", stream_loc);
+        RETURN_ERROR(STATUS_BITMAP_OFFSET_VALIDATION_ERROR);
+    }
+
+    //----------------
+    // Flip the entire image, because BitMap is a weird format.
+    //----------------
+
+    // This is how much space a single line takes up
+    size_t depth = bmp.info_header.v1.bitsPerPixel / 8;
+    size_t pitch = bmp.info_header.v1.width * depth;
+
+    WRITE_DEBUG("Flipping entire image before we write it. depth=", depth, ", pitch=", pitch);
+    std::unique_ptr<unsigned char[]> output(new unsigned char[bmp.info_header.v1.sizeOfBitmap]{ 0 });
+
+    auto res = flipImage(output.get(), bmp.data.get(), pitch, bmp.info_header.v1.height);
+    RETURN_IF_ERROR(res);
+
+    // Only flip the bytes for 24-bit images
+    if(depth == 3) {
+        WRITE_DEBUG("Swapping RGB to BGR before writing the BitMap.");
+        // Swap B and R every 3 pixels since BitMap expects pixels in BGR rather
+        //   than RGB format
+        for(size_t i = 2; i < bmp.info_header.v1.sizeOfBitmap; i += depth) {
+            std::swap(output[i], output[i - 2]);
+        }
+    }
+
+    {
+        WRITE_DEBUG("Image flipped successfully, writing ",
+                    bmp.info_header.v1.sizeOfBitmap, " bytes to file.");
+        auto before = file.tellp();
+        file.write(reinterpret_cast<const char*>(output.get()),
+                   bmp.info_header.v1.sizeOfBitmap);
+        WRITE_DEBUG("Wrote ", (file.tellp() - before), " bytes.");
+    }
+
+    // Close the file and verify if the write succeeded
+    file.close();
+    if(file.bad()) {
+        WRITE_ERROR("badbit set on output file after closing it. Write failed!");
+        RETURN_ERROR(std::error_code(errno, std::generic_category()));
+    }
+
+    return STATUS_SUCCESS;
+
+#undef WRITE_BMP_VALUE
+}
+
+auto HMDT::writeBMP2(const std::filesystem::path& path, unsigned char* data,
+                     uint32_t width, uint32_t height, uint16_t depth,
+                     bool is_greyscale, BMPHeaderToUse hdr_version_to_use)
+    -> MaybeVoid
+{
+    BitMap2 bmp;
+    std::memset(&bmp, 0, sizeof(BitMap2));
+
+    // Make sure we release the grabbed 'data' pointer when we exit, as it is
+    //   not ours to delete
+    RUN_AT_SCOPE_END([&bmp]() {
+        bmp.data.release();
+    });
+
+    auto num_pixels = width * height;
+
+    bmp.file_header.filetype = BM_TYPE;
+    bmp.file_header.fileSize = FILE_HEADER_LENGTH + num_pixels * depth;
+    bmp.file_header.reserved1 = 0;
+    bmp.file_header.reserved2 = 0;
+    bmp.file_header.bitmapOffset = FILE_HEADER_LENGTH;
+
+    auto info_header_size = FILE_HEADER_LENGTH;
+
+    // Fill out the info header based on what version is requested
+    //   Note: we populate it backwards to take advantage of switch-case
+    //   fallthrough
+    switch(hdr_version_to_use) {
+        case BMPHeaderToUse::V5:
+            info_header_size += (V5_INFO_HEADER_LENGTH - V4_INFO_HEADER_LENGTH);
+            WRITE_DEBUG("info_header_size=", info_header_size);
+
+            bmp.info_header.v5.profileData = 0;
+            bmp.info_header.v5.profileSize = 0;
+            bmp.info_header.v5.reserved = 0;
+        case BMPHeaderToUse::V4:
+            info_header_size += (V4_INFO_HEADER_LENGTH - V1_INFO_HEADER_LENGTH);
+            WRITE_DEBUG("info_header_size=", info_header_size);
+
+            bmp.info_header.v4.redMask   = 0x00FF0000;
+            bmp.info_header.v4.greenMask = 0x0000FF00;
+            bmp.info_header.v4.blueMask  = 0x000000FF;
+            bmp.info_header.v4.alphaMask = 0xFF000000;
+            bmp.info_header.v4.CSType = LogicalColorSpace::CALIBRATED_RGB;
+
+            // endpoints
+            bmp.info_header.v4.redX = 0;
+            bmp.info_header.v4.redY = 0;
+            bmp.info_header.v4.redZ = 0;
+            bmp.info_header.v4.greenX = 0;
+            bmp.info_header.v4.greenY = 0;
+            bmp.info_header.v4.greenZ = 0;
+            bmp.info_header.v4.blueX = 0;
+            bmp.info_header.v4.blueY = 0;
+            bmp.info_header.v4.blueZ = 0;
+
+            bmp.info_header.v4.gammaRed = 0;
+            bmp.info_header.v4.gammaGreen = 0;
+            bmp.info_header.v4.gammaBlue = 0;
+        case BMPHeaderToUse::V1:
+            info_header_size += V1_INFO_HEADER_LENGTH;
+            WRITE_DEBUG("info_header_size=", info_header_size);
+
+            bmp.info_header.v1.headerSize = info_header_size;
+            bmp.info_header.v1.width = static_cast<int>(width);
+            bmp.info_header.v1.height = static_cast<int>(height);
+            bmp.info_header.v1.bitPlanes = 1;
+            bmp.info_header.v1.bitsPerPixel = depth * 8; // 8 bits per pixel
+            bmp.info_header.v1.compression = 0; // For Win32 systems, this is BI_RGB
+            bmp.info_header.v1.sizeOfBitmap = num_pixels * depth;
+            bmp.info_header.v1.horzResolution = 0; // TODO: Do we need to set this?
+            bmp.info_header.v1.vertResolution = 0; // TODO: Do we need to set this?
+            bmp.info_header.v1.colorsUsed = 0;
+            bmp.info_header.v1.colorImportant = 0;
+    }
+
+    // Now that we know the info header size, add it to the relevant file header
+    //   fields
+    bmp.file_header.fileSize += info_header_size;
+    bmp.file_header.bitmapOffset += info_header_size;
+
+    if(bmp.info_header.v1.bitsPerPixel <= 8) {
+        switch(bmp.info_header.v1.bitsPerPixel) {
+            case 8:
+                bmp.info_header.v1.colorsUsed = 256;
+                break;
+            case 4:
+                bmp.info_header.v1.colorsUsed = 16;
+                break;
+            case 1:
+                bmp.info_header.v1.colorsUsed = 2;
+                break;
+            default:
+                WRITE_ERROR("Invalid bitsPerPixel<=8! Must be 1, 4, or 8, not ",
+                            bmp.info_header.v1.bitsPerPixel);
+                RETURN_ERROR(STATUS_INVALID_BITS_PER_PIXEL);
+        }
+
+        WRITE_DEBUG("Generating color table with ", bmp.info_header.v1.colorsUsed,
+                    " values.");
+        WRITE_DEBUG("Old File Header values:"
+                    " fileSize=", bmp.file_header.fileSize,
+                    ", bitmapOffset=", bmp.file_header.bitmapOffset,
+                    ", sizeOfBitmap=", bmp.info_header.v1.sizeOfBitmap);
+
+        // Increase all of the sizes and offsets
+        auto color_table_size = sizeof(RGBQuad) * bmp.info_header.v1.colorsUsed;
+        bmp.file_header.fileSize += color_table_size;
+        bmp.file_header.bitmapOffset += color_table_size;
+
+        WRITE_DEBUG("Updated File Header values:"
+                    " fileSize=", bmp.file_header.fileSize,
+                    ", bitmapOffset=", bmp.file_header.bitmapOffset,
+                    ", sizeOfBitmap=", bmp.info_header.v1.sizeOfBitmap);
+
+        bmp.color_table.reset(new RGBQuad[bmp.info_header.v1.colorsUsed]);
+
+        // No need for a default block here, as we already checked that condition
+        //   up above
+        switch(bmp.info_header.v1.bitsPerPixel) {
+            case 8:
+            case 4:
+                if(is_greyscale) {
+                    for(auto i = 0U; i < bmp.info_header.v1.colorsUsed; ++i) {
+                        uint8_t c = i * (0x100 / bmp.info_header.v1.colorsUsed);
+                        bmp.color_table[i] = { { c, c, c, 0x00 } };
+                    }
+                } else {
+                    // TODO: Will we need to even support this case?
+                    RETURN_ERROR(STATUS_NOT_IMPLEMENTED);
+                }
+                break;
+            case 1:
+                bmp.color_table[0] = { { 0xFF, 0xFF, 0xFF, 0x00 } };
+                bmp.color_table[1] = { { 0x00, 0x00, 0x00, 0x00 } };
+                break;
+        }
+    }
+
+    bmp.data.reset(data);
+
+    auto res = writeBMP(path, bmp);
+    RETURN_IF_ERROR(res);
+
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief Outputs a BitMap to an ostream
+ *
+ * @param stream The output stream to write to.
+ * @param bm The BitMap to write.
+ *
+ * @return The given stream after writing the BitMap to it.
+ */
+std::ostream& HMDT::operator<<(std::ostream& stream, const HMDT::BitMap2& bm) {
+    stream << "BitMap = {" << std::endl
+           << "    Header = {" << std::endl
+           << "        filetype = " << bm.file_header.filetype << std::endl
+           << "        fileSize = " << bm.file_header.fileSize << std::endl
+           << "        reserved1 = " << bm.file_header.reserved1 << std::endl
+           << "        reserved2 = " << bm.file_header.reserved2 << std::endl
+           << "        bitmapOffset = " << bm.file_header.bitmapOffset << std::endl
+           << "    }" << std::endl
+           << "    headerSize = " << bm.info_header.v1.headerSize << std::endl
+           << "    width = " << bm.info_header.v1.width << std::endl
+           << "    height = " << bm.info_header.v1.height << std::endl
+           << "    bitPlanes = " << bm.info_header.v1.bitPlanes << std::endl
+           << "    bitsPerPixel = " << bm.info_header.v1.bitsPerPixel << std::endl
+           << "    compression = " << bm.info_header.v1.compression << std::endl
+           << "    sizeOfBitmap = " << bm.info_header.v1.sizeOfBitmap << std::endl
+           << "    horzResolution = " << bm.info_header.v1.horzResolution << std::endl
+           << "    vertResolution = " << bm.info_header.v1.vertResolution << std::endl
+           << "    colorsUsed = " << bm.info_header.v1.colorsUsed << std::endl
+           << "    colorImportant = " << bm.info_header.v1.colorImportant << std::endl;
+
+    // Optionally print out the v4 header if this bitmap has one
+    if(bm.info_header.v1.headerSize >= 108) {
+        stream << "    redMask = " << bm.info_header.v4.redMask << std::endl;
+        stream << "    greenMask = " << bm.info_header.v4.greenMask << std::endl;
+        stream << "    blueMask = " << bm.info_header.v4.blueMask << std::endl;
+        stream << "    alphaMask = " << bm.info_header.v4.alphaMask << std::endl;
+        stream << "    CSType = " << static_cast<uint32_t>(bm.info_header.v4.CSType) << std::endl;
+
+        // endpoints
+        stream << "    endpoints = {" << std::endl
+               << "        red = { " << bm.info_header.v4.redX << " "
+                                     << bm.info_header.v4.redY << " "
+                                     << bm.info_header.v4.redZ << "}" << std::endl
+               << "        green = { " << bm.info_header.v4.greenX << " "
+                                       << bm.info_header.v4.greenY << " "
+                                       << bm.info_header.v4.greenZ << "}" << std::endl
+               << "        blue = { " << bm.info_header.v4.blueX << " "
+                                      << bm.info_header.v4.blueY << " "
+                                      << bm.info_header.v4.blueZ << "}" << std::endl
+               << "    }" << std::endl;
+
+        stream << "    gammaRed = " << bm.info_header.v4.gammaRed << std::endl;
+        stream << "    gammaGreen = " << bm.info_header.v4.gammaGreen << std::endl;
+        stream << "    gammaBlue = " << bm.info_header.v4.gammaBlue << std::endl;
+    }
+
+    // Optionally print out the v5 header if this bitmap has one
+    if(bm.info_header.v1.headerSize >= 124) {
+        stream << "    profileData = " << bm.info_header.v5.profileData << std::endl;
+        stream << "    profileSize = " << bm.info_header.v5.profileSize << std::endl;
+        stream << "    reserved = " << bm.info_header.v5.reserved << std::endl;
+    }
+
+    stream << "    colorTable = { ";
+    if(bm.color_table != nullptr) {
+        for(auto i = 0U; i < bm.info_header.v1.colorsUsed; ++i) {
+            stream << "0x" << std::hex << (static_cast<uint32_t>(bm.color_table[i].blue) << 24 |
+                                           static_cast<uint32_t>(bm.color_table[i].green) << 16 |
+                                           static_cast<uint32_t>(bm.color_table[i].red) << 8 |
+                                           static_cast<uint32_t>(bm.color_table[i].reserved))
+                           << std::dec << ", ";
+        }
+    } else {
+        stream << "<NULL>";
+    }
+    stream << " }" << std::endl
            << "    data = { ... }" << std::endl
            << "}";
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     ${TEST_SRC_DIR}/GuiTests.cpp
     ${TEST_SRC_DIR}/ActionTests.cpp
     ${TEST_SRC_DIR}/PreferencesTests.cpp
+    ${TEST_SRC_DIR}/BitMapTests.cpp
 
     ${TEST_SRC_DIR}/TestOverrides.cpp
     ${TEST_SRC_DIR}/TestUtils.cpp

--- a/tests/bin/8bpp_greyscale.bmp
+++ b/tests/bin/8bpp_greyscale.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa77988d1c8c5242c1266bfe1512d719064a07c91e514e35bc08d6d8102ac556
+size 66682

--- a/tests/bin/8bpp_greyscale_no_color_management.bmp
+++ b/tests/bin/8bpp_greyscale_no_color_management.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d5aa157a1d4f361445db89afb7a0f9f56eb158416e7e556742c0da3b4c871af
+size 66614

--- a/tests/inc/TestUtils.h
+++ b/tests/inc/TestUtils.h
@@ -18,6 +18,8 @@
 
 # define ASSERT_STATUS(VAL, EXPECTED) \
     ASSERT_EQ(VAL.error(), EXPECTED)
+# define ASSERT_SUCCEEDED(VAL)    \
+    ASSERT_TRUE(IS_SUCCESS(VAL)); \
 
 # define TEST_COUT std::cerr << "[          ] [ INFO ]"
 # define TEST_CERR std::cerr << "[          ] [ ERR  ]"

--- a/tests/src/BitMapTests.cpp
+++ b/tests/src/BitMapTests.cpp
@@ -217,6 +217,12 @@ TEST(BitMapTests, WriteSimpleBMP) {
     auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
     auto bmp2_path = write_base_path / "simple_out.bmp";
 
+    if(!std::filesystem::exists(write_base_path)) {
+        TEST_COUT << "Directory " << write_base_path
+                  << " does not exist, creating." << std::endl;
+        ASSERT_TRUE(std::filesystem::create_directory(write_base_path));
+    }
+
     HMDT::BitMap2 bmp1;
     auto res = HMDT::readBMP(bmp1_path, bmp1);
     ASSERT_SUCCEEDED(res);
@@ -300,6 +306,12 @@ TEST(BitMapTests, WriteSimpleBMPWithoutObject) {
     auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "simple.bmp";
     auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
     auto bmp2_path = write_base_path / "simple_out.bmp";
+
+    if(!std::filesystem::exists(write_base_path)) {
+        TEST_COUT << "Directory " << write_base_path
+                  << " does not exist, creating." << std::endl;
+        ASSERT_TRUE(std::filesystem::create_directory(write_base_path));
+    }
 
     WRITE_INFO("Reading BitMap from ", bmp1_path);
     HMDT::BitMap2 bmp1;
@@ -397,6 +409,12 @@ TEST(BitMapTests, Write8BPP) {
     auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "8bpp_greyscale_no_color_management.bmp";
     auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
     auto bmp2_path = write_base_path / "8bpp_greyscale_no_color_management_out.bmp";
+
+    if(!std::filesystem::exists(write_base_path)) {
+        TEST_COUT << "Directory " << write_base_path
+                  << " does not exist, creating." << std::endl;
+        ASSERT_TRUE(std::filesystem::create_directory(write_base_path));
+    }
 
     WRITE_INFO("Reading BitMap from ", bmp1_path);
     HMDT::BitMap2 bmp1;
@@ -513,6 +531,12 @@ TEST(BitMapTests, Write8BPPWithoutObject) {
     auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "8bpp_greyscale_no_color_management.bmp";
     auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
     auto bmp2_path = write_base_path / "8bpp_greyscale_no_color_management_noobj_out.bmp";
+
+    if(!std::filesystem::exists(write_base_path)) {
+        TEST_COUT << "Directory " << write_base_path
+                  << " does not exist, creating." << std::endl;
+        ASSERT_TRUE(std::filesystem::create_directory(write_base_path));
+    }
 
     WRITE_INFO("Reading BitMap from ", bmp1_path);
     HMDT::BitMap2 bmp1;

--- a/tests/src/BitMapTests.cpp
+++ b/tests/src/BitMapTests.cpp
@@ -1,0 +1,578 @@
+
+#include "gtest/gtest.h"
+
+#include <filesystem>
+#include <algorithm>
+
+#include "BitMap.h"
+#include "Constants.h"
+#include "StatusCodes.h"
+#include "Logger.h"
+
+#include "TestUtils.h"
+
+TEST(BitMapTests, SimpleLoadTest) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "simple.bmp";
+
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    TEST_COUT << bmp1 << std::endl;
+
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, HMDT::BM_TYPE);
+    ASSERT_EQ(bmp1.file_header.fileSize, 786554);
+    ASSERT_EQ(bmp1.file_header.reserved1, 0);
+    ASSERT_EQ(bmp1.file_header.reserved2, 0);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, 122); // fileHeader + infoHeaderV4
+    // Check the info header
+
+    // Make sure that we have the right header version (In this case, it should
+    //   be the V4 Info Header)
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, HMDT::V4_INFO_HEADER_LENGTH);
+
+    // If the above assertion is true, we know that we have the V4 header
+    //   However, we should still be able to utilize the v1 variable to access
+    //   the v1 header
+    ASSERT_EQ(bmp1.info_header.v1.width, 512);
+    ASSERT_EQ(bmp1.info_header.v1.height, 512);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, 1);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, 24);
+    ASSERT_EQ(bmp1.info_header.v1.compression, 0);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, 786432);
+    ASSERT_EQ(bmp1.info_header.v1.horzResolution, 2835);
+    ASSERT_EQ(bmp1.info_header.v1.vertResolution, 2835);
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, 0);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, 0);
+
+    // Now verify the V4 part of the header
+    {
+        ASSERT_EQ(bmp1.info_header.v4.redMask, 1934772034);
+        ASSERT_EQ(bmp1.info_header.v4.greenMask, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueMask, 0);
+        ASSERT_EQ(bmp1.info_header.v4.alphaMask, 0);
+        ASSERT_EQ(bmp1.info_header.v4.CSType, HMDT::LogicalColorSpace::CALIBRATED_RGB);
+
+        ASSERT_EQ(bmp1.info_header.v4.redX, 0);
+        ASSERT_EQ(bmp1.info_header.v4.redY, 0);
+        ASSERT_EQ(bmp1.info_header.v4.redZ, 0);
+        ASSERT_EQ(bmp1.info_header.v4.greenX, 0);
+        ASSERT_EQ(bmp1.info_header.v4.greenY, 0);
+        ASSERT_EQ(bmp1.info_header.v4.greenZ, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueX, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueY, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueZ, 2);
+
+        ASSERT_EQ(bmp1.info_header.v4.gammaRed, 0);
+        ASSERT_EQ(bmp1.info_header.v4.gammaGreen, 0);
+        ASSERT_EQ(bmp1.info_header.v4.gammaBlue, 0);
+    }
+
+    // Do not verify the V5 header part, as the size is only 108
+
+    // Verify that there is no color table
+    ASSERT_EQ(bmp1.color_table, nullptr);
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp1.data, nullptr);
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+
+TEST(BitMapTests, Load8BPP) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "8bpp_greyscale_no_color_management.bmp";
+
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    TEST_COUT << bmp1 << std::endl;
+
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, HMDT::BM_TYPE);
+    ASSERT_EQ(bmp1.file_header.fileSize, 1049722);
+    ASSERT_EQ(bmp1.file_header.reserved1, 0);
+    ASSERT_EQ(bmp1.file_header.reserved2, 0);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, 1146); // fileHeader + infoHeaderV4 + color table
+    // Check the info header
+
+    // Make sure that we have the right header version (In this case, it should
+    //   be the V4 Info Header)
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, HMDT::V4_INFO_HEADER_LENGTH);
+
+    // If the above assertion is true, we know that we have the V4 header
+    //   However, we should still be able to utilize the v1 variable to access
+    //   the v1 header
+    ASSERT_EQ(bmp1.info_header.v1.width, 1024);
+    ASSERT_EQ(bmp1.info_header.v1.height, 1024);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, 1);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, 8);
+    ASSERT_EQ(bmp1.info_header.v1.compression, 0);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, 1048576);
+    ASSERT_EQ(bmp1.info_header.v1.horzResolution, 2835);
+    ASSERT_EQ(bmp1.info_header.v1.vertResolution, 2835);
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, 256);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, 256);
+
+    // Now verify the V4 part of the header
+    {
+        ASSERT_EQ(bmp1.info_header.v4.redMask, 1934772034);
+        ASSERT_EQ(bmp1.info_header.v4.greenMask, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueMask, 0);
+        ASSERT_EQ(bmp1.info_header.v4.alphaMask, 0);
+        ASSERT_EQ(bmp1.info_header.v4.CSType, HMDT::LogicalColorSpace::CALIBRATED_RGB);
+
+        ASSERT_EQ(bmp1.info_header.v4.redX, 0);
+        ASSERT_EQ(bmp1.info_header.v4.redY, 0);
+        ASSERT_EQ(bmp1.info_header.v4.redZ, 0);
+        ASSERT_EQ(bmp1.info_header.v4.greenX, 0);
+        ASSERT_EQ(bmp1.info_header.v4.greenY, 0);
+        ASSERT_EQ(bmp1.info_header.v4.greenZ, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueX, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueY, 0);
+        ASSERT_EQ(bmp1.info_header.v4.blueZ, 2);
+
+        ASSERT_EQ(bmp1.info_header.v4.gammaRed, 0);
+        ASSERT_EQ(bmp1.info_header.v4.gammaGreen, 0);
+        ASSERT_EQ(bmp1.info_header.v4.gammaBlue, 0);
+    }
+
+    // Do not verify the V5 header part, as the size is only 108
+
+    // Verify that there is a color table
+    // Not really easy to test the whole color table, so as long as it is
+    //   non-null then we're probably fine (can't really verify the length
+    //   easily)
+    ASSERT_NE(bmp1.color_table, nullptr);
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp1.data, nullptr);
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+
+TEST(BitMapTests, WriteSimpleBMP) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "simple.bmp";
+    auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
+    auto bmp2_path = write_base_path / "simple_out.bmp";
+
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    // Now write that BitMap back to the disk
+    res = HMDT::writeBMP(bmp2_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    // Read the data from the BitMap back into memory
+    HMDT::BitMap2 bmp2;
+    res = HMDT::readBMP(bmp2_path, bmp2);
+    ASSERT_SUCCEEDED(res);
+
+    // And now verify that the file on the disk exactly matches the data we
+    //   initially wrote
+
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, bmp2.file_header.filetype);
+    ASSERT_EQ(bmp1.file_header.fileSize, bmp2.file_header.fileSize);
+    ASSERT_EQ(bmp1.file_header.reserved1, bmp2.file_header.reserved1);
+    ASSERT_EQ(bmp1.file_header.reserved2, bmp2.file_header.reserved2);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, bmp2.file_header.bitmapOffset);
+
+    // Check the info header
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, bmp2.info_header.v1.headerSize);
+    ASSERT_EQ(bmp1.info_header.v1.width, bmp2.info_header.v1.width);
+    ASSERT_EQ(bmp1.info_header.v1.height, bmp2.info_header.v1.height);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, bmp2.info_header.v1.bitPlanes);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, bmp2.info_header.v1.bitsPerPixel);
+    ASSERT_EQ(bmp1.info_header.v1.compression, bmp2.info_header.v1.compression);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, bmp2.info_header.v1.sizeOfBitmap);
+    ASSERT_EQ(bmp1.info_header.v1.horzResolution, bmp2.info_header.v1.horzResolution);
+    ASSERT_EQ(bmp1.info_header.v1.vertResolution, bmp2.info_header.v1.vertResolution);
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, bmp2.info_header.v1.colorsUsed);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, bmp2.info_header.v1.colorImportant);
+
+    // Now verify the V4 part of the header
+    {
+        ASSERT_EQ(bmp1.info_header.v4.redMask, bmp2.info_header.v4.redMask);
+        ASSERT_EQ(bmp1.info_header.v4.greenMask, bmp2.info_header.v4.greenMask);
+        ASSERT_EQ(bmp1.info_header.v4.blueMask,bmp2.info_header.v4.blueMask);
+        ASSERT_EQ(bmp1.info_header.v4.alphaMask, bmp2.info_header.v4.alphaMask);
+        ASSERT_EQ(bmp1.info_header.v4.CSType, bmp2.info_header.v4.CSType);
+
+        ASSERT_EQ(bmp1.info_header.v4.redX, bmp2.info_header.v4.redX);
+        ASSERT_EQ(bmp1.info_header.v4.redY, bmp2.info_header.v4.redY);
+        ASSERT_EQ(bmp1.info_header.v4.redZ, bmp2.info_header.v4.redZ);
+        ASSERT_EQ(bmp1.info_header.v4.greenX, bmp2.info_header.v4.greenX);
+        ASSERT_EQ(bmp1.info_header.v4.greenY, bmp2.info_header.v4.greenY);
+        ASSERT_EQ(bmp1.info_header.v4.greenZ, bmp2.info_header.v4.greenZ);
+        ASSERT_EQ(bmp1.info_header.v4.blueX, bmp2.info_header.v4.blueX);
+        ASSERT_EQ(bmp1.info_header.v4.blueY, bmp2.info_header.v4.blueY);
+        ASSERT_EQ(bmp1.info_header.v4.blueZ, bmp2.info_header.v4.blueZ);
+
+        ASSERT_EQ(bmp1.info_header.v4.gammaRed, bmp2.info_header.v4.gammaRed);
+        ASSERT_EQ(bmp1.info_header.v4.gammaGreen, bmp2.info_header.v4.gammaGreen);
+        ASSERT_EQ(bmp1.info_header.v4.gammaBlue,bmp2.info_header.v4.gammaBlue);
+    }
+
+    // Do not verify the V5 header part, as the size is only 108
+
+    // Verify that there is no color table
+    ASSERT_EQ(bmp2.color_table, nullptr);
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp2.data, nullptr);
+
+    // Now verify that the contents are equal
+    ASSERT_TRUE(std::equal(bmp1.data.get(),
+                           bmp1.data.get() + bmp1.info_header.v1.sizeOfBitmap,
+                           bmp2.data.get()));
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+
+TEST(BitMapTests, WriteSimpleBMPWithoutObject) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "simple.bmp";
+    auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
+    auto bmp2_path = write_base_path / "simple_out.bmp";
+
+    WRITE_INFO("Reading BitMap from ", bmp1_path);
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    WRITE_INFO("Writing BitMap to ", bmp2_path);
+    // Now write that BitMap back to the disk
+    // Don't write using bmp1, test with the raw data + dimensions instead
+    res = HMDT::writeBMP2(bmp2_path, bmp1.data.get(),
+                          bmp1.info_header.v1.width, bmp1.info_header.v1.height,
+                          3 /* depth */, false /* is_greyscale */,
+                          HMDT::BMPHeaderToUse::V4);
+    ASSERT_SUCCEEDED(res);
+
+    WRITE_INFO("Reading BitMap from ", bmp2_path);
+    // Read the data from the BitMap back into memory
+    HMDT::BitMap2 bmp2;
+    res = HMDT::readBMP(bmp2_path, bmp2);
+    ASSERT_SUCCEEDED(res);
+
+    // And now verify that the file on the disk exactly matches the data we
+    //   initially wrote
+
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, bmp2.file_header.filetype);
+    ASSERT_EQ(bmp1.file_header.fileSize, bmp2.file_header.fileSize);
+    ASSERT_EQ(bmp1.file_header.reserved1, bmp2.file_header.reserved1);
+    ASSERT_EQ(bmp1.file_header.reserved2, bmp2.file_header.reserved2);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, bmp2.file_header.bitmapOffset);
+
+    // Check the info header
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, bmp2.info_header.v1.headerSize);
+    ASSERT_EQ(bmp1.info_header.v1.width, bmp2.info_header.v1.width);
+    ASSERT_EQ(bmp1.info_header.v1.height, bmp2.info_header.v1.height);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, bmp2.info_header.v1.bitPlanes);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, bmp2.info_header.v1.bitsPerPixel);
+    ASSERT_EQ(bmp1.info_header.v1.compression, bmp2.info_header.v1.compression);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, bmp2.info_header.v1.sizeOfBitmap);
+    ASSERT_EQ(bmp2.info_header.v1.horzResolution, 0); // TODO: Are these fields
+    ASSERT_EQ(bmp2.info_header.v1.vertResolution, 0); //   required?
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, bmp2.info_header.v1.colorsUsed);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, bmp2.info_header.v1.colorImportant);
+
+    // Now verify the V4 part of the header
+    // This currently will _not_ match the input bitmap, since we do not
+    //   build any part of the V4 header ourselves
+    // TODO: If this changes in the future, make sure to update this unit test
+    //   accordingly
+    {
+
+        ASSERT_EQ(bmp2.info_header.v4.redMask, HMDT::RED_MASK);
+        ASSERT_EQ(bmp2.info_header.v4.greenMask, HMDT::GREEN_MASK);
+        ASSERT_EQ(bmp2.info_header.v4.blueMask, HMDT::BLUE_MASK);
+        ASSERT_EQ(bmp2.info_header.v4.alphaMask, 0xFF000000);
+        ASSERT_EQ(bmp2.info_header.v4.CSType,
+                  HMDT::LogicalColorSpace::CALIBRATED_RGB);
+
+        ASSERT_EQ(bmp2.info_header.v4.redX, 0);
+        ASSERT_EQ(bmp2.info_header.v4.redY, 0);
+        ASSERT_EQ(bmp2.info_header.v4.redZ, 0);
+        ASSERT_EQ(bmp2.info_header.v4.greenX, 0);
+        ASSERT_EQ(bmp2.info_header.v4.greenY, 0);
+        ASSERT_EQ(bmp2.info_header.v4.greenZ, 0);
+        ASSERT_EQ(bmp2.info_header.v4.blueX, 0);
+        ASSERT_EQ(bmp2.info_header.v4.blueY, 0);
+        ASSERT_EQ(bmp2.info_header.v4.blueZ, 0);
+
+        ASSERT_EQ(bmp2.info_header.v4.gammaRed, 0);
+        ASSERT_EQ(bmp2.info_header.v4.gammaGreen, 0);
+        ASSERT_EQ(bmp2.info_header.v4.gammaBlue, 0);
+    }
+
+    // Do not verify the V5 header part, as the size is only 108
+
+    // Verify that there is no color table
+    ASSERT_EQ(bmp2.color_table, nullptr);
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp2.data, nullptr);
+
+    // Now verify that the contents are equal
+    ASSERT_TRUE(std::equal(bmp1.data.get(),
+                           bmp1.data.get() + bmp1.info_header.v1.sizeOfBitmap,
+                           bmp2.data.get()));
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+
+TEST(BitMapTests, Write8BPP) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "8bpp_greyscale_no_color_management.bmp";
+    auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
+    auto bmp2_path = write_base_path / "8bpp_greyscale_no_color_management_out.bmp";
+
+    WRITE_INFO("Reading BitMap from ", bmp1_path);
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    WRITE_DEBUG(bmp1);
+
+    // Now write that BitMap back to the disk
+    WRITE_INFO("Writing BitMap to ", bmp2_path);
+    res = HMDT::writeBMP(bmp2_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    // Read the data from the BitMap back into memory
+    WRITE_INFO("Reading BitMap from ", bmp2_path);
+    HMDT::BitMap2 bmp2;
+    res = HMDT::readBMP(bmp2_path, bmp2);
+    ASSERT_SUCCEEDED(res);
+
+    // And now verify that the file on the disk exactly matches the data we
+    //   initially wrote
+
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, bmp2.file_header.filetype);
+    ASSERT_EQ(bmp1.file_header.fileSize, bmp2.file_header.fileSize);
+    ASSERT_EQ(bmp1.file_header.reserved1, bmp2.file_header.reserved1);
+    ASSERT_EQ(bmp1.file_header.reserved2, bmp2.file_header.reserved2);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, bmp2.file_header.bitmapOffset);
+
+    // Check the info header
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, bmp2.info_header.v1.headerSize);
+    ASSERT_EQ(bmp1.info_header.v1.width, bmp2.info_header.v1.width);
+    ASSERT_EQ(bmp1.info_header.v1.height, bmp2.info_header.v1.height);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, bmp2.info_header.v1.bitPlanes);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, bmp2.info_header.v1.bitsPerPixel);
+    ASSERT_EQ(bmp1.info_header.v1.compression, bmp2.info_header.v1.compression);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, bmp2.info_header.v1.sizeOfBitmap);
+    ASSERT_EQ(bmp1.info_header.v1.horzResolution, bmp2.info_header.v1.horzResolution);
+    ASSERT_EQ(bmp1.info_header.v1.vertResolution, bmp2.info_header.v1.vertResolution);
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, bmp2.info_header.v1.colorsUsed);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, bmp2.info_header.v1.colorImportant);
+
+    // Now verify the V4 part of the header
+    if(bmp1.info_header.v1.headerSize == HMDT::V4_INFO_HEADER_LENGTH) {
+        ASSERT_EQ(bmp1.info_header.v4.redMask, bmp2.info_header.v4.redMask);
+        ASSERT_EQ(bmp1.info_header.v4.greenMask, bmp2.info_header.v4.greenMask);
+        ASSERT_EQ(bmp1.info_header.v4.blueMask,bmp2.info_header.v4.blueMask);
+        ASSERT_EQ(bmp1.info_header.v4.alphaMask, bmp2.info_header.v4.alphaMask);
+        ASSERT_EQ(bmp1.info_header.v4.CSType, bmp2.info_header.v4.CSType);
+
+        ASSERT_EQ(bmp1.info_header.v4.redX, bmp2.info_header.v4.redX);
+        ASSERT_EQ(bmp1.info_header.v4.redY, bmp2.info_header.v4.redY);
+        ASSERT_EQ(bmp1.info_header.v4.redZ, bmp2.info_header.v4.redZ);
+        ASSERT_EQ(bmp1.info_header.v4.greenX, bmp2.info_header.v4.greenX);
+        ASSERT_EQ(bmp1.info_header.v4.greenY, bmp2.info_header.v4.greenY);
+        ASSERT_EQ(bmp1.info_header.v4.greenZ, bmp2.info_header.v4.greenZ);
+        ASSERT_EQ(bmp1.info_header.v4.blueX, bmp2.info_header.v4.blueX);
+        ASSERT_EQ(bmp1.info_header.v4.blueY, bmp2.info_header.v4.blueY);
+        ASSERT_EQ(bmp1.info_header.v4.blueZ, bmp2.info_header.v4.blueZ);
+
+        ASSERT_EQ(bmp1.info_header.v4.gammaRed, bmp2.info_header.v4.gammaRed);
+        ASSERT_EQ(bmp1.info_header.v4.gammaGreen, bmp2.info_header.v4.gammaGreen);
+        ASSERT_EQ(bmp1.info_header.v4.gammaBlue,bmp2.info_header.v4.gammaBlue);
+    }
+
+    // Do not verify the V5 header part, as the size is only 108
+
+    // Verify that there is a color table, as it is required for <=8BPP
+    ASSERT_NE(bmp1.color_table, nullptr);
+    ASSERT_NE(bmp2.color_table, nullptr);
+
+    // Now verify that the contents are equal
+    auto sizeof_color_table = bmp1.info_header.v1.colorsUsed;
+    int i = 0;
+    ASSERT_TRUE(std::equal(bmp1.color_table.get(),
+                           bmp1.color_table.get() + sizeof_color_table,
+                           bmp2.color_table.get(),
+                           [i](auto&& l, auto&& r) mutable {
+                               if(l.rgb_quad != r.rgb_quad) {
+                                   WRITE_ERROR("#", i, ": ",
+                                               l.rgb_quad, " != ",  r.rgb_quad);
+                               }
+                               ++i;
+                               return l.rgb_quad == r.rgb_quad;
+                           }));
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp2.data, nullptr);
+
+    // Now verify that the contents are equal
+    i = 0;
+    ASSERT_TRUE(std::equal(bmp1.data.get(),
+                           bmp1.data.get() + bmp1.info_header.v1.sizeOfBitmap,
+                           bmp2.data.get(),
+                           [i](auto&& l, auto&& r) mutable {
+                               if(l != r) {
+                                   WRITE_ERROR("#", i, ": ",
+                                               static_cast<uint32_t>(l),
+                                               " != ",
+                                               static_cast<uint32_t>(r));
+                               }
+                               ++i;
+                               return l == r;
+                           }));
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+
+TEST(BitMapTests, Write8BPPWithoutObject) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "8bpp_greyscale_no_color_management.bmp";
+    auto write_base_path = HMDT::UnitTests::getTestProgramPath() / "tmp";
+    auto bmp2_path = write_base_path / "8bpp_greyscale_no_color_management_noobj_out.bmp";
+
+    WRITE_INFO("Reading BitMap from ", bmp1_path);
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
+
+    WRITE_DEBUG(bmp1);
+
+    // Now write that BitMap back to the disk
+    WRITE_INFO("Writing BitMap to ", bmp2_path);
+    res = HMDT::writeBMP2(bmp2_path, bmp1.data.get(),
+                          bmp1.info_header.v1.width, bmp1.info_header.v1.height,
+                          1 /* depth */, true /* is_greyscale */,
+                          HMDT::BMPHeaderToUse::V1);
+    ASSERT_SUCCEEDED(res);
+
+    // Read the data from the BitMap back into memory
+    WRITE_INFO("Reading BitMap from ", bmp2_path);
+    HMDT::BitMap2 bmp2;
+    res = HMDT::readBMP(bmp2_path, bmp2);
+    ASSERT_SUCCEEDED(res);
+
+    // And now verify that the file on the disk exactly matches the data we
+    //   initially wrote
+
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, bmp2.file_header.filetype);
+    ASSERT_EQ(bmp1.file_header.fileSize, bmp2.file_header.fileSize);
+    ASSERT_EQ(bmp1.file_header.reserved1, bmp2.file_header.reserved1);
+    ASSERT_EQ(bmp1.file_header.reserved2, bmp2.file_header.reserved2);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, bmp2.file_header.bitmapOffset);
+
+    // Check the info header
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, bmp2.info_header.v1.headerSize);
+    ASSERT_EQ(bmp1.info_header.v1.width, bmp2.info_header.v1.width);
+    ASSERT_EQ(bmp1.info_header.v1.height, bmp2.info_header.v1.height);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, bmp2.info_header.v1.bitPlanes);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, bmp2.info_header.v1.bitsPerPixel);
+    ASSERT_EQ(bmp1.info_header.v1.compression, bmp2.info_header.v1.compression);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, bmp2.info_header.v1.sizeOfBitmap);
+    ASSERT_EQ(bmp2.info_header.v1.horzResolution, 0); // TODO: Are these fields
+    ASSERT_EQ(bmp2.info_header.v1.vertResolution, 0); //   required?
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, bmp2.info_header.v1.colorsUsed);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, bmp2.info_header.v1.colorImportant);
+
+    // Now verify the V4 part of the header
+    if(bmp1.info_header.v1.headerSize == HMDT::V4_INFO_HEADER_LENGTH) {
+        ASSERT_EQ(bmp1.info_header.v4.redMask, bmp2.info_header.v4.redMask);
+        ASSERT_EQ(bmp1.info_header.v4.greenMask, bmp2.info_header.v4.greenMask);
+        ASSERT_EQ(bmp1.info_header.v4.blueMask,bmp2.info_header.v4.blueMask);
+        ASSERT_EQ(bmp1.info_header.v4.alphaMask, bmp2.info_header.v4.alphaMask);
+        ASSERT_EQ(bmp1.info_header.v4.CSType, bmp2.info_header.v4.CSType);
+
+        ASSERT_EQ(bmp1.info_header.v4.redX, bmp2.info_header.v4.redX);
+        ASSERT_EQ(bmp1.info_header.v4.redY, bmp2.info_header.v4.redY);
+        ASSERT_EQ(bmp1.info_header.v4.redZ, bmp2.info_header.v4.redZ);
+        ASSERT_EQ(bmp1.info_header.v4.greenX, bmp2.info_header.v4.greenX);
+        ASSERT_EQ(bmp1.info_header.v4.greenY, bmp2.info_header.v4.greenY);
+        ASSERT_EQ(bmp1.info_header.v4.greenZ, bmp2.info_header.v4.greenZ);
+        ASSERT_EQ(bmp1.info_header.v4.blueX, bmp2.info_header.v4.blueX);
+        ASSERT_EQ(bmp1.info_header.v4.blueY, bmp2.info_header.v4.blueY);
+        ASSERT_EQ(bmp1.info_header.v4.blueZ, bmp2.info_header.v4.blueZ);
+
+        ASSERT_EQ(bmp1.info_header.v4.gammaRed, bmp2.info_header.v4.gammaRed);
+        ASSERT_EQ(bmp1.info_header.v4.gammaGreen, bmp2.info_header.v4.gammaGreen);
+        ASSERT_EQ(bmp1.info_header.v4.gammaBlue,bmp2.info_header.v4.gammaBlue);
+    }
+
+    // Do not verify the V5 header part, as the size is only 108
+
+    // Verify that there is a color table, as it is required for <=8BPP
+    ASSERT_NE(bmp1.color_table, nullptr);
+    ASSERT_NE(bmp2.color_table, nullptr);
+
+    // Now verify that the contents are equal
+    auto sizeof_color_table = bmp1.info_header.v1.colorsUsed;
+    int i = 0;
+    ASSERT_TRUE(std::equal(bmp1.color_table.get(),
+                           bmp1.color_table.get() + sizeof_color_table,
+                           bmp2.color_table.get(),
+                           [i](auto&& l, auto&& r) mutable {
+                               if(l.rgb_quad != r.rgb_quad) {
+                                   WRITE_ERROR("#", i, ": ",
+                                               l.rgb_quad, " != ",  r.rgb_quad);
+                               }
+                               ++i;
+                               return l.rgb_quad == r.rgb_quad;
+                           }));
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp2.data, nullptr);
+
+    // Now verify that the contents are equal
+    i = 0;
+    ASSERT_TRUE(std::equal(bmp1.data.get(),
+                           bmp1.data.get() + bmp1.info_header.v1.sizeOfBitmap,
+                           bmp2.data.get(),
+                           [i](auto&& l, auto&& r) mutable {
+                               if(l != r) {
+                                   WRITE_ERROR("#", i, ": ",
+                                               static_cast<uint32_t>(l),
+                                               " != ",
+                                               static_cast<uint32_t>(r));
+                               }
+                               ++i;
+                               return l == r;
+                           }));
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+

--- a/tests/src/BitMapTests.cpp
+++ b/tests/src/BitMapTests.cpp
@@ -94,14 +94,63 @@ TEST(BitMapTests, Load8BPP) {
     auto res = HMDT::readBMP(bmp1_path, bmp1);
     ASSERT_SUCCEEDED(res);
 
-    TEST_COUT << bmp1 << std::endl;
+    // Check the file header
+    ASSERT_EQ(bmp1.file_header.filetype, HMDT::BM_TYPE);
+    ASSERT_EQ(bmp1.file_header.fileSize, 66614);
+    ASSERT_EQ(bmp1.file_header.reserved1, 0);
+    ASSERT_EQ(bmp1.file_header.reserved2, 0);
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, 1078);
+    // Check the info header
+
+    // Make sure that we have the right header version (In this case, it should
+    //   be the V4 Info Header)
+    ASSERT_EQ(bmp1.info_header.v1.headerSize, HMDT::V1_INFO_HEADER_LENGTH);
+
+    // If the above assertion is true, we know that we have the V4 header
+    //   However, we should still be able to utilize the v1 variable to access
+    //   the v1 header
+    ASSERT_EQ(bmp1.info_header.v1.width, 256);
+    ASSERT_EQ(bmp1.info_header.v1.height, 256);
+    ASSERT_EQ(bmp1.info_header.v1.bitPlanes, 1);
+    ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, 8);
+    ASSERT_EQ(bmp1.info_header.v1.compression, 0);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, 65536);
+    ASSERT_EQ(bmp1.info_header.v1.horzResolution, 11811);
+    ASSERT_EQ(bmp1.info_header.v1.vertResolution, 11811);
+    ASSERT_EQ(bmp1.info_header.v1.colorsUsed, 256);
+    ASSERT_EQ(bmp1.info_header.v1.colorImportant, 256);
+
+    // Do not verify the V4 part of the header as this image has no color management
+
+    // Verify that there is a color table
+    // Not really easy to test the whole color table, so as long as it is
+    //   non-null then we're probably fine (can't really verify the length
+    //   easily)
+    ASSERT_NE(bmp1.color_table, nullptr);
+
+    // Not really easy to test the whole data-set, so as long as it is non-null
+    //   then we're probably fine (can't really verify the length easily)
+    ASSERT_NE(bmp1.data, nullptr);
+
+    HMDT::Log::Logger::getInstance().reset();
+}
+
+TEST(BitMapTests, Load8BPPWithColorManagement) {
+    // We also want to see log outputs in the test output
+    HMDT::UnitTests::registerTestLogOutputFunction(true, true, true, true);
+
+    auto bmp1_path = HMDT::UnitTests::getTestProgramPath() / "bin" / "8bpp_greyscale.bmp";
+
+    HMDT::BitMap2 bmp1;
+    auto res = HMDT::readBMP(bmp1_path, bmp1);
+    ASSERT_SUCCEEDED(res);
 
     // Check the file header
     ASSERT_EQ(bmp1.file_header.filetype, HMDT::BM_TYPE);
-    ASSERT_EQ(bmp1.file_header.fileSize, 1049722);
+    ASSERT_EQ(bmp1.file_header.fileSize, 66682);
     ASSERT_EQ(bmp1.file_header.reserved1, 0);
     ASSERT_EQ(bmp1.file_header.reserved2, 0);
-    ASSERT_EQ(bmp1.file_header.bitmapOffset, 1146); // fileHeader + infoHeaderV4 + color table
+    ASSERT_EQ(bmp1.file_header.bitmapOffset, 1146);
     // Check the info header
 
     // Make sure that we have the right header version (In this case, it should
@@ -111,14 +160,14 @@ TEST(BitMapTests, Load8BPP) {
     // If the above assertion is true, we know that we have the V4 header
     //   However, we should still be able to utilize the v1 variable to access
     //   the v1 header
-    ASSERT_EQ(bmp1.info_header.v1.width, 1024);
-    ASSERT_EQ(bmp1.info_header.v1.height, 1024);
+    ASSERT_EQ(bmp1.info_header.v1.width, 256);
+    ASSERT_EQ(bmp1.info_header.v1.height, 256);
     ASSERT_EQ(bmp1.info_header.v1.bitPlanes, 1);
     ASSERT_EQ(bmp1.info_header.v1.bitsPerPixel, 8);
     ASSERT_EQ(bmp1.info_header.v1.compression, 0);
-    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, 1048576);
-    ASSERT_EQ(bmp1.info_header.v1.horzResolution, 2835);
-    ASSERT_EQ(bmp1.info_header.v1.vertResolution, 2835);
+    ASSERT_EQ(bmp1.info_header.v1.sizeOfBitmap, 65536);
+    ASSERT_EQ(bmp1.info_header.v1.horzResolution, 11811);
+    ASSERT_EQ(bmp1.info_header.v1.vertResolution, 11811);
     ASSERT_EQ(bmp1.info_header.v1.colorsUsed, 256);
     ASSERT_EQ(bmp1.info_header.v1.colorImportant, 256);
 

--- a/tests/src/UtilTests.cpp
+++ b/tests/src/UtilTests.cpp
@@ -131,6 +131,54 @@ TEST(UtilTests, SimpleSafeReadTests) {
     ASSERT_EQ(std::string(read_sdata.get()), sdata);
 }
 
+TEST(UtilTests, SimpleSafeRead2Tests) {
+    std::stringstream sstream;
+
+    // Input data points
+    uint32_t idata = 11234;
+    bool bdata = true;
+    float fdata = 3.14159f;
+    std::string sdata = "foobar";
+
+    // Output data points
+    uint32_t read_idata;
+    bool read_bdata;
+    float read_fdata;
+    std::shared_ptr<char[]> read_sdata(new char[sdata.size() + 1]);
+    uint32_t read_idata2;
+    bool read_bdata2;
+    float read_fdata2;
+
+    // Write data points into the stream
+    HMDT::writeData(sstream, idata);
+    HMDT::writeData(sstream, bdata);
+    HMDT::writeData(sstream, fdata);
+    sstream.write(sdata.c_str(), sdata.size() + 1);
+
+    // Write each data point again
+    HMDT::writeData(sstream, idata, bdata, fdata);
+
+    // Read all of the data out of the stream
+    ASSERT_SUCCEEDED(HMDT::safeRead2(&read_idata, sstream));
+    ASSERT_SUCCEEDED(HMDT::safeRead2(&read_bdata, sstream));
+    ASSERT_SUCCEEDED(HMDT::safeRead2(&read_fdata, sstream));
+
+    // Read one more character than size() for the \0
+    ASSERT_SUCCEEDED(HMDT::safeRead2(read_sdata.get(), sdata.size() + 1, sstream));
+
+    // Read multiple values at once
+    ASSERT_SUCCEEDED(HMDT::safeRead2(sstream, &read_idata2, &read_bdata2, &read_fdata2));
+
+    // Make sure that the data got read back out of the stream correctly
+    ASSERT_EQ(read_idata, idata);
+    ASSERT_EQ(read_bdata, bdata);
+    ASSERT_EQ(read_fdata, fdata);
+    ASSERT_EQ(std::string(read_sdata.get()), sdata);
+    ASSERT_EQ(read_idata2, idata);
+    ASSERT_EQ(read_bdata2, bdata);
+    ASSERT_EQ(read_fdata2, fdata);
+}
+
 TEST(UtilTests, SimpleWriteDataTests) {
     std::stringstream sstream;
 


### PR DESCRIPTION
A refactor of the BitMap structure + API to use better error reporting, memory management, support for different header versions, and proper support for greyscale 8BPP images. This does not replace the usage of the old API throughout the codebase yet as the old API technically still works, but it does deprecate it. Once this PR is completed, a new issue should be created to address the refactor to swap out the APIs and remove the old one.

This refactor is necessary for being able to load 8BPP greyscale bitmaps, which is necessary for loading and exporting heightmaps properly.