### PR TITLE
[FIX] Small fix to the IProject Prompt API

### DIFF
--- a/mod_dev_tool/gui/src/ItemAddFunctions.cpp
+++ b/mod_dev_tool/gui/src/ItemAddFunctions.cpp
@@ -315,9 +315,12 @@ auto HMDT::GUI::addHeightMap(Window& window,
 
         project.getMapProject().getHeightMapProject().setPromptCallback(
             [&window](const std::string& message,
-                      const std::vector<std::string>& opts)
+                      const std::vector<std::string>& opts,
+                      const Project::IProject::PromptType& /*type*/)
                 -> uint32_t
             {
+                // TODO: We should make use of the PromptType here
+
                 // Create a dialog with no buttons, as we will just add the ones
                 //   specified in opts.
                 Gtk::MessageDialog dialog(window,

--- a/mod_dev_tool/project/inc/IProject.h
+++ b/mod_dev_tool/project/inc/IProject.h
@@ -28,10 +28,24 @@ namespace HMDT::Project {
      * @brief The interface for a project
      */
     struct IProject {
+        /**
+         * @brief Defines the different prompt types that might be given to the
+         *        PromptCallback
+         */
+        enum class PromptType {
+            INFO,
+            WARN,
+            ERROR,
+            ALERT,
+            QUESTION,
+        };
+
         //! Callback type for prompting the user with some question
         using PromptCallback = std::function<Maybe<uint32_t>(const std::string&,
-                                                             const std::vector<std::string>&)>;
+                                                             const std::vector<std::string>&,
+                                                             const PromptType&)>;
 
+        IProject();
         virtual ~IProject() = default;
 
         virtual MaybeVoid save(const std::filesystem::path&) = 0;
@@ -49,13 +63,18 @@ namespace HMDT::Project {
 
         protected:
             Maybe<uint32_t> prompt(const std::string&,
-                                   const std::vector<std::string>&);
+                                   const std::vector<std::string>&,
+                                   const PromptType& = PromptType::INFO) const;
+
+            const PromptCallback& getPromptCallback() const noexcept;
 
         private:
-            static PromptCallback DEFAULT_PROMPT_CALLBACK;
+            Maybe<uint32_t> defaultPromptCallback(const std::string&,
+                                                  const std::vector<std::string>&,
+                                                  const PromptType&);
 
             //! A generic callback which can be used to ask the user a question.
-            PromptCallback m_prompt_callback = DEFAULT_PROMPT_CALLBACK;
+            PromptCallback m_prompt_callback;
     };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/src/ProjectTests.cpp
+++ b/tests/src/ProjectTests.cpp
@@ -228,7 +228,9 @@ TEST(ProjectTests, HeightMapProjectLoadWithNon8BPPImage) {
 
     // First test that it fails if the user chooses not to convert the image
     heightmap_project.setPromptCallback(
-        [](const std::string& message, const std::vector<std::string>& opts)
+        [](const std::string& message,
+           const std::vector<std::string>& opts,
+           const HMDT::Project::IProject::PromptType&)
             -> uint32_t
         {
             WRITE_INFO("Mocking prompt asking: '", message, "': Response=1");
@@ -238,7 +240,9 @@ TEST(ProjectTests, HeightMapProjectLoadWithNon8BPPImage) {
     ASSERT_STATUS(res, HMDT::STATUS_INVALID_BIT_DEPTH);
 
     heightmap_project.setPromptCallback(
-        [](const std::string& message, const std::vector<std::string>& opts)
+        [](const std::string& message,
+           const std::vector<std::string>& opts,
+           const HMDT::Project::IProject::PromptType&)
             -> uint32_t
         {
             WRITE_INFO("Mocking prompt asking: '", message, "': Response=-1");
@@ -248,7 +252,9 @@ TEST(ProjectTests, HeightMapProjectLoadWithNon8BPPImage) {
     ASSERT_STATUS(res, HMDT::STATUS_UNEXPECTED_RESPONSE);
 
     heightmap_project.setPromptCallback(
-        [](const std::string& message, const std::vector<std::string>& opts)
+        [](const std::string& message,
+           const std::vector<std::string>& opts,
+           const HMDT::Project::IProject::PromptType&)
             -> uint32_t
         {
             WRITE_INFO("Mocking prompt asking: '", message, "': Response=0");


### PR DESCRIPTION
Added PromptType parameter to prompt/PromptCallback so that prompt callbacks can change how they display the prompt depending on what type of prompt it is. Changed defaultPromptCallback to call up to the root callback if the project is not the root, otherwise to return CALLBACK_NOT_REGISTERED if the project is the root.