### PR TITLE
State Deletion BugFix

### DIFF
--- a/mod_dev_tool/gui/src/StatePropertiesPane.cpp
+++ b/mod_dev_tool/gui/src/StatePropertiesPane.cpp
@@ -261,7 +261,24 @@ void HMDT::GUI::StatePropertiesPane::buildDeleteStateButton() {
                 m_state != nullptr && opt_project)
         {
             auto& history_project = opt_project->get().getHistoryProject();
-            history_project.getStateProject().removeState(m_state->id);
+            auto result = history_project.getStateProject().removeState(m_state->id);
+
+            if(IS_FAILURE(result)) {
+                std::stringstream ss;
+                ss << "Failed to delete state #" << m_state->id << ".";
+
+                std::stringstream ss2;
+                ss2 << "Reason: 0x"
+                   << std::hex << result.error().value() << std::dec
+                   << " '" << result.error().message() << "'";
+
+                Gtk::MessageDialog dialog(*this, ss.str(),
+                                          false, Gtk::MESSAGE_ERROR);
+                dialog.set_secondary_text(ss2.str());
+                dialog.run();
+
+                return;
+            }
 
             SelectionManager::getInstance().removeStateSelection(m_state->id);
         }

--- a/mod_dev_tool/gui/src/StatePropertiesPane.cpp
+++ b/mod_dev_tool/gui/src/StatePropertiesPane.cpp
@@ -272,7 +272,7 @@ void HMDT::GUI::StatePropertiesPane::buildDeleteStateButton() {
                    << std::hex << result.error().value() << std::dec
                    << " '" << result.error().message() << "'";
 
-                Gtk::MessageDialog dialog(*this, ss.str(),
+                Gtk::MessageDialog dialog(ss.str(),
                                           false, Gtk::MESSAGE_ERROR);
                 dialog.set_secondary_text(ss2.str());
                 dialog.run();

--- a/mod_dev_tool/project/inc/IProject.h
+++ b/mod_dev_tool/project/inc/IProject.h
@@ -179,7 +179,7 @@ namespace HMDT::Project {
         virtual const StateMap& getStates() const = 0;
 
         virtual StateID addNewState(const std::vector<uint32_t>&) = 0;
-        virtual void removeState(StateID) = 0;
+        virtual MaybeVoid removeState(StateID) noexcept = 0;
 
         virtual State& getStateForIterator(StateMap::const_iterator) = 0;
         virtual const State& getStateForIterator(StateMap::const_iterator) const = 0;

--- a/mod_dev_tool/project/inc/StateProject.h
+++ b/mod_dev_tool/project/inc/StateProject.h
@@ -44,7 +44,7 @@ namespace HMDT::Project {
             virtual const StateMap& getStates() const override;
 
             virtual StateID addNewState(const std::vector<uint32_t>&) override;
-            virtual void removeState(StateID) override;
+            virtual MaybeVoid removeState(StateID) noexcept override;
 
             virtual State& getStateForIterator(StateMap::const_iterator) override;
             virtual const State& getStateForIterator(StateMap::const_iterator) const override;

--- a/mod_dev_tool/project/src/MapProject.cpp
+++ b/mod_dev_tool/project/src/MapProject.cpp
@@ -291,7 +291,7 @@ auto HMDT::Project::MapProject::validateProvinceStateID(StateID province_state_i
         const auto& state_project = getRootParent().getHistoryProject().getStateProject();
 
         if(!state_project.isValidStateID(province_state_id)) {
-            WRITE_WARN("Province has state ID of ", province_state_id, " which is invalid!");
+            WRITE_WARN("Province ", province_id, " has state ID of ", province_state_id, " which is invalid!");
             return STATUS_PROVINCE_INVALID_STATE_ID;
         }
 

--- a/mod_dev_tool/project/src/StateProject.cpp
+++ b/mod_dev_tool/project/src/StateProject.cpp
@@ -463,6 +463,13 @@ auto HMDT::Project::StateProject::addNewState(const std::vector<uint32_t>& provi
  * @param id The ID of the state to delete
  */
 void HMDT::Project::StateProject::removeState(StateID id) {
+    const auto& state = m_states.at(id);
+
+    // Disconnect each province from this state first
+    for(auto&& prov_id : state.provinces) {
+        getRootParent().getMapProject().getProvinceProject().getProvinceForLabel(prov_id).state = -1;
+    }
+
     m_available_state_ids.push(id);
     m_states.erase(id);
 

--- a/mod_dev_tool/project/src/StateProject.cpp
+++ b/mod_dev_tool/project/src/StateProject.cpp
@@ -462,18 +462,24 @@ auto HMDT::Project::StateProject::addNewState(const std::vector<uint32_t>& provi
  *
  * @param id The ID of the state to delete
  */
-void HMDT::Project::StateProject::removeState(StateID id) {
-    const auto& state = m_states.at(id);
+auto HMDT::Project::StateProject::removeState(StateID id) noexcept -> MaybeVoid
+{
+    MaybeRef<State> state = getStateForID(id);
+    RETURN_IF_ERROR(state);
 
-    // Disconnect each province from this state first
-    for(auto&& prov_id : state.provinces) {
-        getRootParent().getMapProject().getProvinceProject().getProvinceForLabel(prov_id).state = -1;
-    }
+    state.andThen([this](const State& state) {
+        // Disconnect each province from this state first
+        for(auto&& prov_id : state.provinces) {
+            getRootParent().getMapProject().getProvinceProject().getProvinceForLabel(prov_id).state = -1;
+        }
+    });
 
     m_available_state_ids.push(id);
     m_states.erase(id);
 
     updateStateIDMatrix();
+
+    return STATUS_SUCCESS;
 }
 
 auto HMDT::Project::StateProject::getStateForIterator(StateMap::const_iterator cit)


### PR DESCRIPTION
Fixes a bug that would break projects when deleting a state (as provinces would still be referring to their state even after it was deleted).