### PR TITLE
Signal Handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ else()
 
     if(DEBUG_BUILD)
         message(STATUS "Including debug symbols in build!")
-        add_compile_options(-g)
+        add_compile_options(-g -fsanitize=address -fsanitize-recover=address)
+        add_link_options(-fsanitize=address -fsanitize-recover=address)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(HoI4ModDevelopmentTool CXX ASM)
 
 set(MSYS_PREFIX "C:/msys64" CACHE PATH "Prefix for where packages are installed to with MSYS. Only applies to WIN32.")
 set(DEBUG_BUILD OFF CACHE BOOL "Specifies if builds should be built with debugging information.")
+set(DEBUG_ENABLE_ASAN OFF CACHE BOOL "Specifies if builds should be built with ASAN.")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -56,7 +57,12 @@ else()
 
     if(DEBUG_BUILD)
         message(STATUS "Including debug symbols in build!")
-        add_compile_options(-g -fsanitize=address -fsanitize-recover=address)
+        add_compile_options(-g)
+    endif()
+
+    if(DEBUG_ENABLE_ASAN)
+        message(STATUS "Enabling ASAN. Note that this build will not be able to be used with other memory checking tools, such as valgrind.")
+        add_compile_options(-fsanitize=address -fsanitize-recover=address)
         add_link_options(-fsanitize=address -fsanitize-recover=address)
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ properly or compile. As such, I will not describe how to compile with MSVC here.
 #### Using MSYS2
 
 Make sure you install [MSYS](https://www.msys2.org/wiki/MSYS2-installation/)
-first, and run the following commands in an MSYS2 shell.
+first, and run the following commands in an MSYS2-MINGW shell.
 
 ```
 $ ./win32.bootstrap.sh

--- a/mod_dev_tool/common/CMakeLists.txt
+++ b/mod_dev_tool/common/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(common PRIVATE "${CMAKE_BINARY_DIR}")
 target_link_libraries(common PRIVATE nlohmann_json::nlohmann_json uuid)
 
 if(WIN32)
-    target_link_libraries(common PRIVATE rpcrt4.lib)
+    target_link_libraries(common PRIVATE rpcrt4.lib dbghelp)
 endif()
 
 target_link_libraries(common PUBLIC unique_colors logging)

--- a/mod_dev_tool/common/inc/Util.h
+++ b/mod_dev_tool/common/inc/Util.h
@@ -467,6 +467,9 @@ namespace HMDT {
 
     std::filesystem::path getExecutablePath();
 
+    void dumpBacktrace(FILE* = stderr, std::uint32_t = 63,
+                       int tid = -1) noexcept;
+
     /**
      * @brief Will split the given string, transform each value using the
      *        given unary function, and place each result into the output

--- a/mod_dev_tool/common/src/Util.cpp
+++ b/mod_dev_tool/common/src/Util.cpp
@@ -10,6 +10,7 @@
 
 #ifdef _WIN32
 # include "windows.h"
+# include "Dbghelp.h"
 # ifndef PATH_MAX
 #  define PATH_MAX FILENAME_MAX
 # endif

--- a/mod_dev_tool/common/src/Util.cpp
+++ b/mod_dev_tool/common/src/Util.cpp
@@ -421,7 +421,7 @@ void HMDT::dumpBacktrace(FILE* out_file, std::uint32_t max_frames, int tid) noex
                                   &displacement,
                                   symbol_info);
         if (result == TRUE) {
-            std::fprintf(out_file, "  %s : %s+0x%08x\n",
+            std::fprintf(out_file, "  %s : %s+0x%08llx\n",
                          module_path.generic_string().c_str(),
                          symbol_info->Name,
                          displacement);

--- a/mod_dev_tool/exe/src/ArgParser.cpp
+++ b/mod_dev_tool/exe/src/ArgParser.cpp
@@ -18,20 +18,20 @@ static std::string program_name = "hoi4_mod_dev_tool";
  * @brief Prints help information to the console.
  */
 void HMDT::printHelp() {
-    std::cout << program_name << " [OPTIONS...] {[INFILE] [OUTPATH]}";
-    std::cout << "\t   --no-gui                Alias for --headless.";
-    std::cout << "\t   --no-skip-no-name-state Do not skip states with no name.";
-    std::cout << "\t   --state-input           The input file for writing state definitions.";
-    std::cout << "\t   --height-map            The input file for writing the normal map.";
-    std::cout << "\t   --hoi4-install-path     The installation path for Hearts of Iron 4.";
-    std::cout << "\t   --output-stages         Output every stage of the shape detection algorithm.";
-    std::cout << "\t   --headless              Should the application run in headless mode (without the GUI). Note that this requires [INFIILE] and [OUTPATH] to be provided.";
-    std::cout << "\t   --debug                 Should debugging features be enabled.";
-    std::cout << "\t   --dont-write-logfiles   Should log files get written to a file.";
-    std::cout << "\t   --fix-warnings-on-load  Whether or not problems in a project file should attempt to be fixed when they are loaded.";
-    std::cout << "\t-v,--verbose               Display all output.";
-    std::cout << "\t-q,--quiet                 Display only errors and warnings (does not affect this message).";
-    std::cout << "\t-h,--help                  Display this message and exit.";
+    std::cout << program_name << " [OPTIONS...] {[INFILE] [OUTPATH]}" << std::endl;
+    std::cout << "\t   --no-gui                Alias for --headless." << std::endl;
+    std::cout << "\t   --no-skip-no-name-state Do not skip states with no name." << std::endl;
+    std::cout << "\t   --state-input           The input file for writing state definitions." << std::endl;
+    std::cout << "\t   --height-map            The input file for writing the normal map." << std::endl;
+    std::cout << "\t   --hoi4-install-path     The installation path for Hearts of Iron 4." << std::endl;
+    std::cout << "\t   --output-stages         Output every stage of the shape detection algorithm." << std::endl;
+    std::cout << "\t   --headless              Should the application run in headless mode (without the GUI). Note that this requires [INFIILE] and [OUTPATH] to be provided." << std::endl;
+    std::cout << "\t   --debug                 Should debugging features be enabled." << std::endl;
+    std::cout << "\t   --dont-write-logfiles   Should log files get written to a file." << std::endl;
+    std::cout << "\t   --fix-warnings-on-load  Whether or not problems in a project file should attempt to be fixed when they are loaded." << std::endl;
+    std::cout << "\t-v,--verbose               Display all output." << std::endl;
+    std::cout << "\t-q,--quiet                 Display only errors and warnings (does not affect this message)." << std::endl;
+    std::cout << "\t-h,--help                  Display this message and exit." << std::endl;
 }
 
 /**

--- a/mod_dev_tool/exe/src/main.cpp
+++ b/mod_dev_tool/exe/src/main.cpp
@@ -18,8 +18,8 @@
 # define WIN32_LEAN_AND_MEAN
 # include <Windows.h>
 # include <shlwapi.h>
+# include <dbghelp.h>
 # include "shlobj.h"
-# include "minidumpapiset.h"
 # ifdef ERROR
 #  undef ERROR // This is necessary because we define ERROR in an enum, but windows defines it as something else
 # endif

--- a/mod_dev_tool/logging/inc/Logger.h
+++ b/mod_dev_tool/logging/inc/Logger.h
@@ -8,6 +8,7 @@
 # include <thread>
 # include <sstream>
 # include <iomanip>
+# include <condition_variable>
 
 # include "Source.h"
 # include "Message.h"
@@ -104,6 +105,8 @@ namespace HMDT::Log {
             //  testing
             void reset();
 
+            void waitForLogger() const noexcept;
+
         private:
             /**
              * @brief Builds a Message object
@@ -164,6 +167,15 @@ namespace HMDT::Log {
 
             //! The thread where update() gets called from
             std::thread m_worker_thread;
+
+            /**
+             * @brief Condition variable used to signal to other threads that
+             *        Logger has finished processing a batch of messages.
+             */
+            mutable std::condition_variable m_wait_cv;
+
+            //! Mutex for locking the condition
+            mutable std::mutex m_wait_mutex;
 
             //! The list of output functions
             static std::vector<OutputFunction> output_funcs;

--- a/win32.bootstrap.sh
+++ b/win32.bootstrap.sh
@@ -1,3 +1,3 @@
 
-pacman -S --noconfirm mingw-w64-x86_64-gtkmm3 mingw-w64-x86_64-cmake mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-gettext
+pacman -S --noconfirm mingw-w64-x86_64-gtkmm3 mingw-w64-x86_64-cmake mingw-w64-x86_64-glew mingw-w64-x86_64-glm mingw-w64-x86_64-gettext mingw-w64-x86_64-toolchain
 


### PR DESCRIPTION
Implements signal handling in order to ensure that the logger is properly flushed even in the event of a catastrophic failure (such as a `SIGSEGV`) and that backtraces for all threads are dumped, as well as enables ASAN for debug builds.

Also fixes a minor issue with `--help` which was missing newlines after each message.