### PR TITLE
Fix State Creation not Visible

### DIFF
--- a/mod_dev_tool/actions/CMakeLists.txt
+++ b/mod_dev_tool/actions/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 add_library(actions STATIC
     src/ActionManager.cpp
     src/CreateRemoveContinentAction.cpp
+    src/CreateRemoveStateAction.cpp
 )
 
 target_include_directories(actions PUBLIC inc)

--- a/mod_dev_tool/actions/inc/CreateRemoveStateAction.h
+++ b/mod_dev_tool/actions/inc/CreateRemoveStateAction.h
@@ -1,0 +1,61 @@
+#ifndef CREATEREMOVESTATEACTION_H
+# define CREATEREMOVESTATEACTION_H
+
+# include <string>
+# include <optional>
+# include <vector>
+
+# include "IProject.h"
+
+# include "IAction.h"
+
+namespace HMDT::Action {
+    /**
+     * @brief An action that creates or removes a state
+     */
+    class CreateRemoveStateAction: public Action::IAction {
+        public:
+            using OnValueChangedCallback = std::function<void(const StateID&)>;
+
+            /**
+             * @brief The type of operation this action is doing
+             */
+            enum class Type {
+                CREATE,
+                REMOVE
+            };
+
+            CreateRemoveStateAction(Project::IRootHistoryProject&,
+                                    const std::vector<ProvinceID>&);
+            CreateRemoveStateAction(Project::IRootHistoryProject&,
+                                    const StateID&);
+
+            virtual bool doAction(const Callback& = _) override;
+            virtual bool undoAction(const Callback& = _) override;
+
+            CreateRemoveStateAction& onValueChanged(const OnValueChangedCallback&) noexcept;
+            CreateRemoveStateAction& onCreate(const OnValueChangedCallback&) noexcept;
+            CreateRemoveStateAction& onRemove(const OnValueChangedCallback&) noexcept;
+
+        protected:
+            bool create();
+            bool remove();
+
+        private:
+            // TODO: This is potentially dangerous to hold onto, we should
+            //   instead try to find an elegant solution for getting the current
+            //   map project, as it is potentially possible for the map project
+            //   to go out of scope before this action is destroyed
+            Project::IRootHistoryProject& m_history_project;
+            std::vector<ProvinceID> m_provinces;
+            StateID m_state_id;
+            Type m_type;
+
+            OnValueChangedCallback m_on_value_changed_callback;
+            OnValueChangedCallback m_on_create_callback;
+            OnValueChangedCallback m_on_remove_callback;
+    };
+}
+
+#endif
+

--- a/mod_dev_tool/actions/src/CreateRemoveStateAction.cpp
+++ b/mod_dev_tool/actions/src/CreateRemoveStateAction.cpp
@@ -1,0 +1,121 @@
+
+#include "CreateRemoveStateAction.h"
+
+#include "Logger.h"
+
+/**
+ * @brief Constructs a state creation action.
+ *
+ * @param history_project The history project
+ * @param provinces The provinces to create a state with
+ */
+HMDT::Action::CreateRemoveStateAction::CreateRemoveStateAction(
+        Project::IRootHistoryProject& history_project,
+        const std::vector<ProvinceID>& provinces):
+    m_history_project(history_project),
+    m_provinces(provinces),
+    m_type(Type::CREATE),
+    m_on_value_changed_callback([](auto&&...){}),
+    m_on_create_callback([](auto&&...){}),
+    m_on_remove_callback([](auto&&...){})
+{ }
+
+/**
+ * @brief Constructs a state removal action.
+ *
+ * @param history_project The history project
+ * @param id The id of the state to remove
+ */
+HMDT::Action::CreateRemoveStateAction::CreateRemoveStateAction(
+        Project::IRootHistoryProject& history_project,
+        const StateID& id):
+    m_history_project(history_project),
+    m_provinces(),
+    m_state_id(id),
+    m_type(Type::REMOVE),
+    m_on_value_changed_callback([](auto&&...){}),
+    m_on_create_callback([](auto&&...){}),
+    m_on_remove_callback([](auto&&...){})
+{ }
+
+bool HMDT::Action::CreateRemoveStateAction::doAction(const Callback& callback) {
+    if(!callback(0)) return false;
+
+    switch(m_type) {
+        case Type::CREATE:
+            if(!create()) return false;
+            break;
+        case Type::REMOVE:
+            if(!remove()) return false;
+            break;
+    }
+
+    if(!callback(1)) return false;
+
+    return true;
+}
+
+bool HMDT::Action::CreateRemoveStateAction::undoAction(const Callback& callback)
+{
+    if(!callback(0)) return false;
+
+    switch(m_type) {
+        case Type::CREATE:
+            if(!remove()) return false;
+            break;
+        case Type::REMOVE:
+            if(!create()) return false;
+            break;
+    }
+
+    if(!callback(1)) return false;
+
+    return true;
+}
+
+auto HMDT::Action::CreateRemoveStateAction::onValueChanged(const OnValueChangedCallback& callback) noexcept
+    -> CreateRemoveStateAction&
+{
+    m_on_value_changed_callback = callback;
+    return *this;
+}
+
+auto HMDT::Action::CreateRemoveStateAction::onCreate(const OnValueChangedCallback& callback) noexcept
+    -> CreateRemoveStateAction&
+{
+    m_on_create_callback = callback;
+    return *this;
+}
+
+auto HMDT::Action::CreateRemoveStateAction::onRemove(const OnValueChangedCallback& callback) noexcept
+    -> CreateRemoveStateAction&
+{
+    m_on_remove_callback = callback;
+    return *this;
+}
+
+bool HMDT::Action::CreateRemoveStateAction::create() {
+    // TODO: WARNING!!!! This action will not create a state with the same ID as
+    //   before when undoing! To fix this, StateProject needs a way to add a
+    //   state along with an existing ID.
+    m_state_id = m_history_project.getStateProject().addNewState(m_provinces);
+
+    m_on_create_callback(m_state_id);
+    m_on_value_changed_callback(m_state_id);
+
+    return true;
+}
+
+bool HMDT::Action::CreateRemoveStateAction::remove() {
+    auto maybe_state = m_history_project.getStateProject().getStateForID(m_state_id);
+    RETURN_VALUE_IF_ERROR(maybe_state, false);
+
+    m_provinces = maybe_state->get().provinces;
+    m_history_project.getStateProject().removeState(m_state_id);
+
+    m_on_remove_callback(m_state_id);
+    m_on_value_changed_callback(m_state_id);
+
+    return true;
+}
+

--- a/mod_dev_tool/common/inc/MapData.h
+++ b/mod_dev_tool/common/inc/MapData.h
@@ -108,6 +108,8 @@ namespace HMDT {
         public:
             void setLabelMatrix(InternalMapType32);
             void setStateIDMatrix(InternalMapType32);
+
+            void updateStateIDMatrixTag() noexcept;
     };
 }
 

--- a/mod_dev_tool/common/src/MapData.cpp
+++ b/mod_dev_tool/common/src/MapData.cpp
@@ -114,11 +114,20 @@ void HMDT::MapData::setLabelMatrix(InternalMapType32 label_matrix) {
 
 void HMDT::MapData::setStateIDMatrix(uint32_t state_id_matrix[]) {
     m_state_id_matrix.reset(state_id_matrix);
-    ++m_state_id_matrix_updated_tag;
+    updateStateIDMatrixTag();
 }
 
 void HMDT::MapData::setStateIDMatrix(InternalMapType32 state_id_matrix) {
     m_state_id_matrix = state_id_matrix;
+    updateStateIDMatrixTag();
+}
+
+/**
+ * @brief Updates the tag for the state ID matrix, to mark that it has been
+ *        modified and any systems that use it (such as gui/gl) need to be
+ *        updated as well.
+ */
+void HMDT::MapData::updateStateIDMatrixTag() noexcept {
     ++m_state_id_matrix_updated_tag;
 }
 

--- a/mod_dev_tool/gui/inc/BaseMainWindow.h
+++ b/mod_dev_tool/gui/inc/BaseMainWindow.h
@@ -40,8 +40,26 @@ namespace HMDT::GUI {
             BaseMainWindow();
             virtual ~BaseMainWindow() = default;
 
+            template<typename T>
+            T& getPartAs(const PartType& part) noexcept {
+                static_assert(std::is_base_of_v<BaseMainWindow, T>,
+                              "All parts must inherit from BaseMainWindow.");
+
+                return dynamic_cast<T&>(getPart(part));
+            }
+
+            template<typename T>
+            const T& getPartAs(const PartType& part) const noexcept {
+                static_assert(std::is_base_of_v<BaseMainWindow, T>,
+                              "All parts must inherit from BaseMainWindow.");
+
+                return dynamic_cast<const T&>(getPart(part));
+            }
+
         protected:
             virtual void updatePart(const PartType&, const std::any&) noexcept = 0;
+            virtual BaseMainWindow& getPart(const PartType&) noexcept = 0;
+            virtual const BaseMainWindow& getPart(const PartType&) const noexcept = 0;
     };
 }
 

--- a/mod_dev_tool/gui/inc/MainWindow.h
+++ b/mod_dev_tool/gui/inc/MainWindow.h
@@ -46,7 +46,16 @@ namespace HMDT::GUI {
             OptionalReference<LogViewerWindow> getLogViewerWindow();
 
             template<typename T>
-            T* thisAs() const noexcept {
+            const T* thisAs() const noexcept {
+                static_assert(std::is_base_of_v<T, MainWindow>,
+                              "Can only get MainWindow as one if its base "
+                              "classes.");
+
+                return dynamic_cast<const T*>(this);
+            }
+
+            template<typename T>
+            T* thisAs() noexcept {
                 static_assert(std::is_base_of_v<T, MainWindow>,
                               "Can only get MainWindow as one if its base "
                               "classes.");
@@ -56,6 +65,8 @@ namespace HMDT::GUI {
 
         protected:
             virtual void updatePart(const PartType&, const std::any&) noexcept override;
+            virtual BaseMainWindow& getPart(const PartType&) noexcept override;
+            virtual const BaseMainWindow& getPart(const PartType&) const noexcept override;
 
             virtual Gtk::Orientation getDisplayOrientation() const override;
             virtual void addWidgetToParent(Gtk::Widget&) override;

--- a/mod_dev_tool/gui/inc/MainWindowFileTreePart.h
+++ b/mod_dev_tool/gui/inc/MainWindowFileTreePart.h
@@ -42,6 +42,11 @@ namespace HMDT::GUI {
             void setOnNodeClickCallback(const NodeClickCallback&) noexcept;
             void setOnNodeDoubleClickCallback(const NodeClickCallback&) noexcept;
 
+            MaybeVoid addNodeToHierarchy(const Project::Hierarchy::Key&,
+                                         Project::Hierarchy::INodePtr,
+                                         const std::string& = "") noexcept;
+            MaybeVoid removeNodeFromHierarchy(const Project::Hierarchy::Key&) noexcept;
+
         protected:
             /**
              * @brief Defines the model for representing the project hierarchy
@@ -82,6 +87,8 @@ namespace HMDT::GUI {
                                    const OrderedChildrenMap&,
                                    const NodeIndexMap&);
 
+                    HierarchyModel(const HierarchyModel&);
+
                     virtual ~HierarchyModel() = default;
 
                     std::shared_ptr<Project::Hierarchy::INode> getHierarchy() noexcept;
@@ -104,6 +111,10 @@ namespace HMDT::GUI {
                     bool isValid(const iterator&) const noexcept;
 
                     Maybe<Project::Hierarchy::Key> getKeyForNode(Project::Hierarchy::INodePtr) const noexcept;
+
+                    const ParentMap& getParentMap() const noexcept;
+                    const OrderedChildrenMap& getOrderedChildrenMap() const noexcept;
+                    const NodeIndexMap& getNodeIndexMap() const noexcept;
 
                 protected:
                     Maybe<std::string> valueAsString(const Project::Hierarchy::IPropertyNode&) const noexcept;
@@ -147,12 +158,19 @@ namespace HMDT::GUI {
 
             MaybeVoid onProjectOpened();
 
+            Maybe<std::tuple<HierarchyModel::ParentMap,
+                             HierarchyModel::OrderedChildrenMap,
+                             HierarchyModel::NodeIndexMap>>
+                buildMappingsFrom(const Project::Hierarchy::INodePtr&,
+                                  const Project::Hierarchy::Key& = Project::Hierarchy::Key{}) const noexcept;
+
             MaybeVoid handleNodeValueSelection(Project::Hierarchy::INode*,
                                                std::vector<std::pair<ProvinceID, OnSelectNodeData>>&,
                                                std::vector<std::pair<StateID, OnSelectNodeData>>&,
                                                OnSelectNodeData&);
 
             void updateFileTree(const Project::Hierarchy::Key&) noexcept;
+            MaybeVoid refreshModel(const Project::Hierarchy::Key&) noexcept;
 
             void selectNode(const std::vector<Project::Hierarchy::Key>&,
                             const SelectionManager::Action&) noexcept;

--- a/mod_dev_tool/gui/inc/ProvincePropertiesPane.h
+++ b/mod_dev_tool/gui/inc/ProvincePropertiesPane.h
@@ -20,6 +20,8 @@
 # include "ProvincePreviewDrawingArea.h"
 
 namespace HMDT::GUI {
+    class BaseMainWindow;
+
     /**
      * @brief The pane where properties of a province are placed into
      */
@@ -27,7 +29,7 @@ namespace HMDT::GUI {
         public:
             using ValueChangedCallback = std::function<void(const Project::Hierarchy::Key&)>;
 
-            ProvincePropertiesPane();
+            ProvincePropertiesPane(BaseMainWindow&);
 
             Gtk::ScrolledWindow& getParent();
 
@@ -67,6 +69,8 @@ namespace HMDT::GUI {
             void setPreview(ProvincePreviewDrawingArea::DataPtr);
 
         private:
+            BaseMainWindow& m_main_window;
+
             //! The province currently being acted upon
             Province* m_province;
 

--- a/mod_dev_tool/gui/src/MainWindow.cpp
+++ b/mod_dev_tool/gui/src/MainWindow.cpp
@@ -786,6 +786,36 @@ void HMDT::GUI::MainWindow::updatePart(const PartType& part, const std::any& dat
     }
 }
 
+auto HMDT::GUI::MainWindow::getPart(const PartType& part) noexcept
+    -> BaseMainWindow&
+{
+    switch(part) {
+        case PartType::MAIN:
+            return *this;
+        case PartType::DRAWING_AREA:
+            return *thisAs<MainWindowDrawingAreaPart>();
+        case PartType::PROPERTIES_PANE:
+            return *thisAs<MainWindowPropertiesPanePart>();
+        case PartType::FILE_TREE:
+            return *thisAs<MainWindowFileTreePart>();
+    }
+}
+
+auto HMDT::GUI::MainWindow::getPart(const PartType& part) const noexcept
+    -> const BaseMainWindow&
+{
+    switch(part) {
+        case PartType::MAIN:
+            return *this;
+        case PartType::DRAWING_AREA:
+            return *thisAs<MainWindowDrawingAreaPart>();
+        case PartType::PROPERTIES_PANE:
+            return *thisAs<MainWindowPropertiesPanePart>();
+        case PartType::FILE_TREE:
+            return *thisAs<MainWindowFileTreePart>();
+    }
+}
+
 Gtk::Orientation HMDT::GUI::MainWindow::getDisplayOrientation() const {
     return Gtk::Orientation::ORIENTATION_VERTICAL;
 }

--- a/mod_dev_tool/gui/src/MainWindowFileTreePart.cpp
+++ b/mod_dev_tool/gui/src/MainWindowFileTreePart.cpp
@@ -1,5 +1,7 @@
 #include "MainWindowFileTreePart.h"
 
+#include <numeric>
+
 #include "gtkmm/icontheme.h"
 
 #include "StatusCodes.h"
@@ -57,6 +59,22 @@ HMDT::GUI::MainWindowFileTreePart::HierarchyModel::HierarchyModel(Project::Hiera
     m_ordered_children_map(ordered_children_map),
     m_node_index_map(node_index_map),
     m_stamp(++next_stamp)
+{
+    WRITE_DEBUG("HierarchyModel(", printNode(node, true),
+                ", parent_map[count=", parent_map.size(),
+                "], ord_children_map[count=", ordered_children_map.size(),
+                "], node_index_map[count=", node_index_map.size(), "]), stamp=",
+                m_stamp);
+}
+
+HMDT::GUI::MainWindowFileTreePart::HierarchyModel::HierarchyModel(const HierarchyModel& old_model):
+    Glib::ObjectBase(typeid(HierarchyModel)), // Register a custom GType
+    Glib::Object(), // The custom GType is actually registered here
+    m_project_hierarchy(old_model.m_project_hierarchy),
+    m_parent_map(old_model.m_parent_map),
+    m_ordered_children_map(old_model.m_ordered_children_map),
+    m_node_index_map(old_model.m_node_index_map),
+    m_stamp(old_model.m_stamp) // do not update next_stamp
 { }
 
 /**
@@ -934,6 +952,24 @@ auto HMDT::GUI::MainWindowFileTreePart::HierarchyModel::valueAsString(const Proj
 #undef RETURN_PROVTYPE
 }
 
+auto HMDT::GUI::MainWindowFileTreePart::HierarchyModel::getParentMap() const noexcept
+    -> const ParentMap&
+{
+    return m_parent_map;
+}
+
+auto HMDT::GUI::MainWindowFileTreePart::HierarchyModel::getOrderedChildrenMap() const noexcept
+    -> const OrderedChildrenMap&
+{
+    return m_ordered_children_map;
+}
+
+auto HMDT::GUI::MainWindowFileTreePart::HierarchyModel::getNodeIndexMap() const noexcept
+    -> const NodeIndexMap&
+{
+    return m_node_index_map;
+}
+
 /**
  * @brief Gets the icon for the given type
  *
@@ -1309,6 +1345,77 @@ auto HMDT::GUI::MainWindowFileTreePart::getHierarchy() noexcept
     return m_model->getHierarchy();
 }
 
+
+/**
+ * @brief Builds all mappings needed by HierarchyModel for true_root_node,
+ *        starting from the (optionally) specified key.
+ *
+ * @param true_root_node The root of the entire tree.
+ * @param key A key to the node to start building mappings from, relative to
+ *            true_root_node
+ *
+ * @return A tuple containing the mappings, or an error code upon failure.
+ */
+auto HMDT::GUI::MainWindowFileTreePart::buildMappingsFrom(const Project::Hierarchy::INodePtr& true_root_node,
+                                                          const Project::Hierarchy::Key& key) const noexcept
+    -> Maybe<std::tuple<HierarchyModel::ParentMap,
+                        HierarchyModel::OrderedChildrenMap,
+                        HierarchyModel::NodeIndexMap>>
+{
+    HierarchyModel::ParentMap parent_map;
+    HierarchyModel::OrderedChildrenMap ordered_children_map;
+    HierarchyModel::NodeIndexMap node_index_map;
+
+    // Find the starting place to start building mappings from
+    auto maybe_root_node = key.lookup(true_root_node);
+    RETURN_IF_ERROR(maybe_root_node);
+
+    auto root_node = *maybe_root_node;
+
+    // The root has no parent
+    parent_map[true_root_node.get()] = nullptr;
+    node_index_map[true_root_node.get()] = 0;
+
+    // Resolve links and build parent map
+    auto result = root_node->visit([&true_root_node,
+                                    &parent_map,
+                                    &ordered_children_map,
+                                    &node_index_map](auto node)
+        -> MaybeVoid
+    {
+        if(node->getType() == Project::Hierarchy::Node::Type::LINK) {
+            WRITE_DEBUG("Resolve link node ", node->getName());
+            auto link_node = std::dynamic_pointer_cast<Project::Hierarchy::LinkNode>(node);
+            auto result = link_node->resolve(true_root_node);
+            RETURN_IF_ERROR(result);
+
+            if(!link_node->isLinkValid()) {
+                WRITE_ERROR("Link resolution succeeded, but the link node is still invalid.");
+                RETURN_ERROR(STATUS_UNEXPECTED);
+            }
+        } else if(auto gnode = std::dynamic_pointer_cast<Project::Hierarchy::IGroupNode>(node);
+                  gnode != nullptr)
+        {
+            auto&& children = gnode->getChildren();
+
+            WRITE_DEBUG("Found group node ",
+                        std::to_string((Project::Hierarchy::INode&)*gnode),
+                        ", adding all ", children.size(),
+                        " children to the maps.");
+            for(auto&& [_, child] : children) {
+                parent_map[child.get()] = gnode;
+                ordered_children_map[node.get()].push_back(child);
+                node_index_map[child.get()] = ordered_children_map[node.get()].size() - 1;
+            }
+        }
+
+        return STATUS_SUCCESS;
+    });
+    RETURN_IF_ERROR(result);
+
+    return std::make_tuple(parent_map, ordered_children_map, node_index_map);
+}
+
 /**
  * @brief Callback invoked when a project is opened
  *
@@ -1325,50 +1432,11 @@ auto HMDT::GUI::MainWindowFileTreePart::onProjectOpened() -> MaybeVoid {
 
         auto root_node = *maybe_hierarchy;
 
-        HierarchyModel::ParentMap parent_map;
-        HierarchyModel::OrderedChildrenMap ordered_children_map;
-        HierarchyModel::NodeIndexMap node_index_map;
+        auto mappings = buildMappingsFrom(root_node);
+        RETURN_IF_ERROR(mappings);
 
-        // The root has no parent
-        parent_map[root_node.get()] = nullptr;
-        node_index_map[root_node.get()] = 0;
-
-        // Resolve links and build parent map
-        auto result = root_node->visit([&root_node,
-                                        &parent_map,
-                                        &ordered_children_map,
-                                        &node_index_map](auto node)
-            -> MaybeVoid
-        {
-            if(node->getType() == Project::Hierarchy::Node::Type::LINK) {
-                WRITE_DEBUG("Resolve link node ", node->getName());
-                auto link_node = std::dynamic_pointer_cast<Project::Hierarchy::LinkNode>(node);
-                auto result = link_node->resolve(root_node);
-                RETURN_IF_ERROR(result);
-
-                if(!link_node->isLinkValid()) {
-                    WRITE_ERROR("Link resolution succeeded, but the link node is still invalid.");
-                    RETURN_ERROR(STATUS_UNEXPECTED);
-                }
-            } else if(auto gnode = std::dynamic_pointer_cast<Project::Hierarchy::IGroupNode>(node);
-                      gnode != nullptr)
-            {
-                auto&& children = gnode->getChildren();
-
-                WRITE_DEBUG("Found group node ",
-                            std::to_string((Project::Hierarchy::INode&)*gnode),
-                            ", adding all ", children.size(),
-                            " children to the maps.");
-                for(auto&& [_, child] : children) {
-                    parent_map[child.get()] = gnode;
-                    ordered_children_map[node.get()].push_back(child);
-                    node_index_map[child.get()] = ordered_children_map[node.get()].size() - 1;
-                }
-            }
-
-            return STATUS_SUCCESS;
-        });
-        RETURN_IF_ERROR(result);
+        // Build mappings from root
+        auto [parent_map, ordered_children_map, node_index_map] = *mappings;
 
         // We have to make a new object every time a project is opened in order
         //   to force TreeView to be refreshed
@@ -1380,6 +1448,186 @@ auto HMDT::GUI::MainWindowFileTreePart::onProjectOpened() -> MaybeVoid {
         // Make sure that we refresh the model with the new data
         m_tree_view->set_model(m_model);
     }
+
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief Refreshes the model used by GTK. Only valid if a model already exists
+ *
+ * @return STATUS_SUCCESS if the model could be successfully refreshed, failure
+ *         otherwise.
+ */
+auto HMDT::GUI::MainWindowFileTreePart::refreshModel(const Project::Hierarchy::Key& key) noexcept
+    -> MaybeVoid
+{
+    RETURN_ERROR_IF(!m_model, STATUS_PARAM_CANNOT_BE_NULL);
+
+    auto root_node = m_model->getHierarchy();
+
+    auto mappings = buildMappingsFrom(root_node, key);
+    RETURN_IF_ERROR(mappings);
+
+    // Get updated versions of the mappings, override older data if found
+    auto [parent_map, ordered_children_map, node_index_map] = *mappings;
+
+    // Insert the old map elements into the new elements, effectively
+    //   "overwriting" the old elements with newer ones if applicable
+    parent_map.insert(m_model->getParentMap().begin(),
+                      m_model->getParentMap().end());
+    ordered_children_map.insert(m_model->getOrderedChildrenMap().begin(),
+                                m_model->getOrderedChildrenMap().end());
+    node_index_map.insert(m_model->getNodeIndexMap().begin(),
+                          m_model->getNodeIndexMap().end());
+
+    // This is potentially very spammy, so only do it if debugging is turned on
+    if(prog_opts.debug) {
+        // Dump difference between new map and old map
+        HierarchyModel::ParentMap diff;
+
+        for(auto&& pair : parent_map) {
+            if(m_model->getParentMap().count(pair.first) == 0) {
+                diff.insert(pair);
+            }
+        }
+        for(auto&& pair : m_model->getParentMap()) {
+            if(parent_map.count(pair.first) == 0) {
+                diff.insert(pair);
+            }
+        }
+
+        WRITE_DEBUG("ParentMap diff=[",
+                std::accumulate(diff.begin(), diff.end(), std::string(),
+                    [](auto&& s, auto&& p) {
+                        return s + ", " + printNode(p.first, true) + "=" + printNode(p.second, true);
+                    }), "]");
+
+        // Verify that every node in the hierarchy has a parent in the parent
+        //   map
+        const auto& parent_map_temp = parent_map;
+        root_node->visit([this, &parent_map_temp](auto node) -> MaybeVoid {
+            if(parent_map_temp.count(node.get()) == 0) {
+                WRITE_WARN("Node ", printNode(node, true),
+                           " was not found in parent map!! Was it at least in"
+                           " the original parent map?");
+                if(m_model->getParentMap().count(node.get()) == 0) {
+                    WRITE_ERROR("Node ", printNode(node, true), " also was not "
+                                "in the original map!");
+                } else {
+                    WRITE_DEBUG("Node ", printNode(node, true), " was in the "
+                                "original map. It mapped to ",
+                                printNode(m_model->getParentMap().at(node.get()), true));
+                }
+            }
+
+            return STATUS_SUCCESS;
+        });
+    }
+
+    // Create an exact copy of the model to force TreeView to be refreshed with
+    //   the new data
+    m_model = Glib::RefPtr<HierarchyModel>(new HierarchyModel(root_node,
+                                                              parent_map,
+                                                              ordered_children_map,
+                                                              node_index_map));
+
+    // Make sure that we refresh the model with the new data
+    m_tree_view->set_model(m_model);
+
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief Adds a node to the hierarchy.
+ * @details Important: This function does not update or notify GTK that the
+ *          hierarchy/model has been updated. For that, you must also call
+ *          updateFileTree (or BaseMainWindow::updatePart)
+ *
+ * @param key The root key for where to add the node to
+ * @param node The node to add
+ * @param name The name to add the key as
+ *
+ * @return STATUS_SUCCESS on success, or a failure code otherwise
+ */
+auto HMDT::GUI::MainWindowFileTreePart::addNodeToHierarchy(const Project::Hierarchy::Key& key,
+                                                           Project::Hierarchy::INodePtr node,
+                                                           const std::string& name) noexcept
+    -> MaybeVoid
+{
+    WRITE_DEBUG("Asked to add a node ", printNode(node, true), " at key ", std::to_string(key));
+
+    auto maybe_group_node = key.lookup(m_model->getHierarchy());
+    if(IS_FAILURE(maybe_group_node)) {
+        WRITE_ERROR("Failed to lookup node for key ", std::to_string(key));
+        RETURN_IF_ERROR(maybe_group_node);
+    }
+
+    // Try to convert it to a group node, if we cannot then something has gone
+    //   wrong
+    if(auto gnode = std::dynamic_pointer_cast<Project::Hierarchy::GroupNode>(*maybe_group_node);
+            gnode != nullptr)
+    {
+        if(name.empty()) {
+            auto result = gnode->addChild(node);
+            RETURN_IF_ERROR(result);
+        } else {
+            auto result = gnode->addChild(name, node);
+            RETURN_IF_ERROR(result);
+        }
+    } else {
+        WRITE_WARN("Node ", printNode(node, true), " is marked"
+                   " as a group node, but we failed to cast it to"
+                   " an IGroupNode object.");
+        RETURN_ERROR(STATUS_UNEXPECTED);
+    }
+
+    // Refresh the tree model to notify GTK of a new node, and where that node
+    //   is located
+    auto result = refreshModel(key);
+    RETURN_IF_ERROR(result);
+
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief Attempt to remove the node located at key from its parent
+ *
+ * @param key The key of the node to remove
+ *
+ * @return STATUS_SUCCESS if the removal was successful, an error code otherwise
+ */
+auto HMDT::GUI::MainWindowFileTreePart::removeNodeFromHierarchy(const Project::Hierarchy::Key& key) noexcept
+    -> MaybeVoid
+{
+    WRITE_DEBUG("Asked to remove a node found at key ", std::to_string(key));
+
+    // Lookup the parent key
+    auto maybe_group_node = key.parent().lookup(m_model->getHierarchy());
+    if(IS_FAILURE(maybe_group_node)) {
+        WRITE_ERROR("Failed to lookup node for key ", std::to_string(key));
+        RETURN_IF_ERROR(maybe_group_node);
+    }
+
+    // Try to convert it to a group node, if we cannot then something has gone
+    //   wrong
+    if(auto gnode = std::dynamic_pointer_cast<Project::Hierarchy::GroupNode>(*maybe_group_node);
+            gnode != nullptr)
+    {
+        auto child_name = key.getParts().back();
+
+        auto result = gnode->removeChild(child_name);
+        RETURN_IF_ERROR(result);
+    } else {
+        WRITE_WARN("Node ", printNode(*maybe_group_node, true), " is marked"
+                   " as a group node, but we failed to cast it to"
+                   " an IGroupNode object.");
+        RETURN_ERROR(STATUS_UNEXPECTED);
+    }
+
+    // Refresh the tree model to notify GTK of a new node, and where that node
+    //   is located
+    auto result = refreshModel(key);
+    RETURN_IF_ERROR(result);
 
     return STATUS_SUCCESS;
 }

--- a/mod_dev_tool/gui/src/MainWindowPropertiesPanePart.cpp
+++ b/mod_dev_tool/gui/src/MainWindowPropertiesPanePart.cpp
@@ -47,7 +47,7 @@ Gtk::Frame* HMDT::GUI::MainWindowPropertiesPanePart::buildPropertiesPane(Gtk::Pa
     auto properties_tab = addActiveWidget<Gtk::Notebook>();
 
     {
-        m_province_properties_pane.reset(new ProvincePropertiesPane);
+        m_province_properties_pane.reset(new ProvincePropertiesPane(*this));
         m_province_properties_pane->init();
         m_province_properties_pane->setCallbackOnValueChanged([this](const Project::Hierarchy::Key& key) {
             updatePart(BaseMainWindow::PartType::FILE_TREE, key);

--- a/mod_dev_tool/project/hierarchy/inc/INode.h
+++ b/mod_dev_tool/project/hierarchy/inc/INode.h
@@ -346,6 +346,10 @@ namespace HMDT::Project::Hierarchy {
             Key(const std::vector<std::string>&);
             Key(std::initializer_list<std::string>);
 
+            Key parent() const noexcept;
+
+            Key operator/(const std::string&) const noexcept;
+
             Maybe<INodePtr> lookup(INodePtr) const noexcept;
 
             const std::vector<std::string>& getParts() const noexcept;

--- a/mod_dev_tool/project/hierarchy/src/INode.cpp
+++ b/mod_dev_tool/project/hierarchy/src/INode.cpp
@@ -248,6 +248,34 @@ HMDT::Project::Hierarchy::Key::Key(std::initializer_list<std::string> parts):
 { }
 
 /**
+ * @brief Gets the parent of this key
+ *
+ * @return The parent of this key (includes parts - the last one)
+ */
+auto HMDT::Project::Hierarchy::Key::parent() const noexcept -> Key {
+    return Key(std::vector<std::string>(m_parts.begin(), m_parts.end() - 1));
+}
+
+/**
+ * @brief Creates a new key containing the specified part
+ *
+ * @param part The part to append to this key
+ *
+ * @return A new key containing this key followed by part
+ */
+auto HMDT::Project::Hierarchy::Key::operator/(const std::string& part) const noexcept
+    -> Key
+{
+    // Construct a new key from {existing parts}/part
+    std::vector<std::string> parts;
+    parts.reserve(m_parts.size() + 1);
+    parts.insert(parts.end(), m_parts.begin(), m_parts.end());
+    parts.push_back(part);
+
+    return Key(parts);
+}
+
+/**
  * @brief Looks up a node using this key starting from the given root.
  *
  * @param root The root to start searching from

--- a/mod_dev_tool/project/inc/IProject.h
+++ b/mod_dev_tool/project/inc/IProject.h
@@ -17,6 +17,7 @@
 # include "Terrain.h"
 
 # include "INode.h"
+# include "StateNode.h"
 
 // Forward declarations
 namespace HMDT {
@@ -197,6 +198,8 @@ namespace HMDT::Project {
 
         MaybeRef<const State> getStateForID(StateID) const;
         MaybeRef<State> getStateForID(StateID);
+
+        std::shared_ptr<Hierarchy::StateNode> createStateNode(const StateID&, const State&) const noexcept;
 
         virtual const StateMap& getStates() const = 0;
 

--- a/mod_dev_tool/project/src/IProject.cpp
+++ b/mod_dev_tool/project/src/IProject.cpp
@@ -553,6 +553,61 @@ auto HMDT::Project::IStateProject::getStateForID(StateID state_id)
     return STATUS_STATE_DOES_NOT_EXIST;
 }
 
+/**
+ * @brief Helper that creates a state node from an id and state
+ *
+ * @param id The id of the state.
+ * @param state The state to make a node for
+ *
+ * @return A shared_ptr of a new StateNode
+ */
+auto HMDT::Project::IStateProject::createStateNode(const StateID& id, const State& state) const noexcept
+    -> std::shared_ptr<Hierarchy::StateNode>
+{
+    auto state_node = std::make_shared<Hierarchy::StateNode>(state.name);
+    auto state_id = id;
+
+    state_node->setID([_this=const_cast<IStateProject*>(this), state_id]()
+            -> auto&
+        {
+            return _this->getStateMap()[state_id].id;
+        },
+        [](auto&&...){ return STATUS_SUCCESS; } /* visitor */);
+    state_node->setManpower([_this=const_cast<IStateProject*>(this),
+                             state_id]() -> auto&
+        {
+            return _this->getStateMap()[state_id].manpower;
+        },
+        [](auto&&...){ return STATUS_SUCCESS; });
+    state_node->setCategory([_this=const_cast<IStateProject*>(this),
+                             state_id]() -> auto&
+        {
+            return _this->getStateMap()[state_id].category;
+        },
+        [](auto&&...){ return STATUS_SUCCESS; });
+    state_node->setBuildingsMaxLevelFactor([_this=const_cast<IStateProject*>(this),
+                                            state_id]() -> auto&
+        {
+            return _this->getStateMap()[state_id].buildings_max_level_factor;
+        },
+        [](auto&&...){ return STATUS_SUCCESS; });
+    state_node->setImpassable([_this=const_cast<IStateProject*>(this),
+                               state_id]() -> auto&
+        {
+            return _this->getStateMap()[state_id].impassable;
+        },
+        [](auto&&...){ return STATUS_SUCCESS; });
+
+    // Since this is a DynamicGroup for States, setting the
+    //   provinces statically should be fine, but we may want to
+    //   change this to somehow produce a DynamicGroup instead?
+    WRITE_DEBUG("Add ", state.provinces.size(), " provinces to state node.");
+    state_node->setProvinces(state.provinces,
+                             [](auto&&...){ return STATUS_SUCCESS; });
+
+    return state_node;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void HMDT::Project::IContinentProject::addNewContinent(const std::string& continent)

--- a/mod_dev_tool/project/src/StateProject.cpp
+++ b/mod_dev_tool/project/src/StateProject.cpp
@@ -588,46 +588,7 @@ auto HMDT::Project::StateProject::visitStates(const std::function<MaybeVoid(std:
 
     const auto& children = states_group_node->getChildren();
     for(auto&& [id, state] : m_states) {
-        auto state_node = std::make_shared<Hierarchy::StateNode>(state.name);
-        auto state_id = id;
-
-        state_node->setID([_this=const_cast<StateProject*>(this), state_id]()
-                -> auto&
-            {
-                return _this->m_states[state_id].id;
-            },
-            [](auto&&...){ return STATUS_SUCCESS; } /* visitor */);
-        state_node->setManpower([_this=const_cast<StateProject*>(this),
-                                 state_id]() -> auto&
-            {
-                return _this->m_states[state_id].manpower;
-            },
-            [](auto&&...){ return STATUS_SUCCESS; });
-        state_node->setCategory([_this=const_cast<StateProject*>(this),
-                                 state_id]() -> auto&
-            {
-                return _this->m_states[state_id].category;
-            },
-            [](auto&&...){ return STATUS_SUCCESS; });
-        state_node->setBuildingsMaxLevelFactor([_this=const_cast<StateProject*>(this),
-                                                state_id]() -> auto&
-            {
-                return _this->m_states[state_id].buildings_max_level_factor;
-            },
-            [](auto&&...){ return STATUS_SUCCESS; });
-        state_node->setImpassable([_this=const_cast<StateProject*>(this),
-                                   state_id]() -> auto&
-            {
-                return _this->m_states[state_id].impassable;
-            },
-            [](auto&&...){ return STATUS_SUCCESS; });
-
-        // Since this is a DynamicGroup for States, setting the
-        //   provinces statically should be fine, but we may want to
-        //   change this to somehow produce a DynamicGroup instead?
-        WRITE_DEBUG("Add ", state.provinces.size(), " provinces to state node.");
-        state_node->setProvinces(state.provinces,
-                                 [](auto&&...){ return STATUS_SUCCESS; });
+        auto state_node = createStateNode(id, state);
 
         // Find out how many children share the same name as this state
         uint32_t count = 0;
@@ -646,4 +607,5 @@ auto HMDT::Project::StateProject::visitStates(const std::function<MaybeVoid(std:
 
     return states_group_node;
 }
+
 

--- a/mod_dev_tool/project/src/StateProject.cpp
+++ b/mod_dev_tool/project/src/StateProject.cpp
@@ -388,6 +388,8 @@ void HMDT::Project::StateProject::updateStateIDMatrix() {
 
     auto* label_matrix_start = label_matrix.get();
 
+    // Rebuilds the state ID matrix
+    // This is a kind of expensive operation, so we should do it very infrequently
     parallelTransform(label_matrix_start, label_matrix_start + getMapData()->getProvincesSize(),
                       state_id_matrix.get(),
                       [this](ProvinceID prov_id) -> StateID {
@@ -400,6 +402,8 @@ void HMDT::Project::StateProject::updateStateIDMatrix() {
                               return 0;
                           }
                       });
+
+    getMapData()->updateStateIDMatrixTag();
 
     if(prog_opts.debug) {
         auto path = getRootParent().getDebugRoot();
@@ -607,5 +611,4 @@ auto HMDT::Project::StateProject::visitStates(const std::function<MaybeVoid(std:
 
     return states_group_node;
 }
-
 


### PR DESCRIPTION
Fixes two separate issues which caused creating States to not be visible until the program is rebooted. This makes sure that the file tree is updated when a new state is added, as well as that the StateRendering view will show the new state on the map.

Also adds in a new Action for creating/removing states, allowing the act of doing so to be undone and redone.